### PR TITLE
Allow filtering of metrics by dimension values

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ The configuration is in JSON, an example with common options:
   "region": "eu-west-1",
   "metrics": [
     {"aws_namespace": "AWS/ELB", "aws_metric_name": "RequestCount",
-     "aws_dimensions": ["AvailabilityZone", "LoadBalancerName"], "aws_statistics": ["Sum"]},
+     "aws_dimensions": ["AvailabilityZone", "LoadBalancerName"],
+     "aws_dimension_select": {"LoadBalancerName": ["myLB"]},
+     "aws_statistics": ["Sum"]},
   ]
 }
 ```
@@ -37,6 +39,7 @@ metrics  | Required. A list of CloudWatch metrics to retrieve and export
 aws_namespace  | Required. Namespace of the CloudWatch metric.
 aws_metric_name  | Required. Metric name of the CloudWatch metric.
 aws_dimensions | Optional. Which dimension to fan out over.
+aws_dimension_select | Optional. Which dimension values to filter. Specify a json object with the dimension name as key and an array of dimension values as value.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 300s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -229,6 +229,35 @@ public class CloudWatchCollectorTest {
   }
 
   @Test
+  public void testDimensionSelect() throws Exception {
+    new CloudWatchCollector(
+        ("{`region`: `reg`, `metrics`: [{`aws_namespace`: `AWS/ELB`, `aws_metric_name`: `RequestCount`, "
+            + "`aws_dimensions`: [`AvailabilityZone`, `LoadBalancerName`], `aws_dimension_select`: {`LoadBalancerName`: [`myLB`]}}]}")
+            .replace('`', '"'), client).register(registry);
+
+    Mockito.when(client.listMetrics((ListMetricsRequest)argThat(
+        new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName"))))
+        .thenReturn(new ListMetricsResult().withMetrics(
+            new Metric().withDimensions(new Dimension().withName("AvailabilityZone").withValue("a"), new Dimension().withName("LoadBalancerName").withValue("myLB")),
+            new Metric().withDimensions(new Dimension().withName("AvailabilityZone").withValue("b"), new Dimension().withName("LoadBalancerName").withValue("myLB")),
+            new Metric().withDimensions(new Dimension().withName("AvailabilityZone").withValue("a"), new Dimension().withName("LoadBalancerName").withValue("myOtherLB"))));
+
+    Mockito.when(client.getMetricStatistics((GetMetricStatisticsRequest)argThat(
+        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(new GetMetricStatisticsResult().withDatapoints(
+            new Datapoint().withTimestamp(new Date()).withAverage(2.0)));
+
+    Mockito.when(client.getMetricStatistics((GetMetricStatisticsRequest)argThat(
+        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(new GetMetricStatisticsResult().withDatapoints(
+            new Datapoint().withTimestamp(new Date()).withAverage(2.0)));
+
+    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "a", "myLB"}), .01);
+    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "b", "myLB"}), .01);
+    assertNull(registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "a", "myOtherLB"}));
+  }
+
+  @Test
   public void testGetDimensionsUsesNextToken() throws Exception {
     new CloudWatchCollector(
         ("{`region`: `reg`, `metrics`: [{`aws_namespace`: `AWS/ELB`, `aws_metric_name`: `RequestCount`, "


### PR DESCRIPTION
In order to avoid fetching all metrics for one Namespace (eg. `AWS/ELB`), I would like to introduce the possibility to filter metrics, by a metric dimension value.
That allows to have the following config to only get metrics for a single ELB named `myLB`:
```
{
  "region": "eu-west-1",
  "delay_seconds": 600,
  "metrics": [
    {
      "aws_namespace": "AWS/ELB",
      "aws_metric_name": "RequestCount",
      "aws_dimensions": [
        "AvailabilityZone",
        "LoadBalancerName:myLB"
      ],
      "aws_statistics": ["Sum"],
      "period_seconds": 300
    }
  ]
}
``` 