### PR TITLE
@brian.brazil@robustperception.io - delay_seconds really is 600s! - https://github.com/prometheus/cloudwatch_exporter/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ aws_metric_name  | Required. Metric name of the CloudWatch metric.
 aws_dimensions | Optional. Which dimension to fan out over.
 aws_dimension_select | Optional. Which dimension values to filter. Specify a json object with the dimension name as key and an array of dimension values as value.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics.
-delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 300s. Can be set globally and per metric.
+delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
 


### PR DESCRIPTION
…blob/354c1f69f94db12d28908e686a702106fcf58f1a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java#L79

this has gotten me and my team 2 times now trying to find the extra delay looking for a 10 min reason