### PR TITLE
Use the help text when it is specified in the rule

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -259,9 +259,9 @@ public class CloudWatchCollector extends Collector {
     }
 
     private String help(MetricRule rule, String unit, String statistic) {
-        if (rule.help != null) {
-            return rule.help;
-        }
+      if (rule.help != null) {
+          return rule.help;
+      }
       return "CloudWatch metric " + rule.awsNamespace + " " + rule.awsMetricName
           + " Dimensions: " + rule.awsDimensions + " Statistic: " + statistic
           + " Unit: " + unit;

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -259,6 +259,9 @@ public class CloudWatchCollector extends Collector {
     }
 
     private String help(MetricRule rule, String unit, String statistic) {
+        if (rule.help != null) {
+            return rule.help;
+        }
       return "CloudWatch metric " + rule.awsNamespace + " " + rule.awsMetricName
           + " Dimensions: " + rule.awsDimensions + " Statistic: " + statistic
           + " Unit: " + unit;


### PR DESCRIPTION
Use the help text if it is provided in the description, otherwise use the generated help text.