### PR TITLE
@beorn@soundcloud.com -- Use the help text when it is specified in th…

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -259,6 +259,9 @@ public class CloudWatchCollector extends Collector {
     }
 
     private String help(MetricRule rule, String unit, String statistic) {
+      if (rule.help != null) {
+          return rule.help;
+      }
       return "CloudWatch metric " + rule.awsNamespace + " " + rule.awsMetricName
           + " Dimensions: " + rule.awsDimensions + " Statistic: " + statistic
           + " Unit: " + unit;


### PR DESCRIPTION
…e rule

Using the help field when it is specified in the definition. Otherwise the generated help text is returned like earlier. Also, Fixing the spaces.