### PR TITLE
updated dependency version for AWS Java SDK Cloudwatch to 1.10.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.9.13</version>
+      <version>1.10.34</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>


### PR DESCRIPTION
We need to update the version for the AWS Java SDK Cloudwatch to get the metrics for AWS Aurora.

Cheers