### PR TITLE
Use config.yml instead of config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
     rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
 WORKDIR /
 
-ONBUILD ADD config.json /
-ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.json" ]
+ONBUILD ADD config.yml /
+ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ metrics  | Required. A list of CloudWatch metrics to retrieve and export
 aws_namespace  | Required. Namespace of the CloudWatch metric.
 aws_metric_name  | Required. Metric name of the CloudWatch metric.
 aws_dimensions | Optional. Which dimension to fan out over.
-aws_dimension_select | Optional. Which dimension values to filter. Specify a json object with the dimension name as key and an array of dimension values as value.
-aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expressoin. Specify a json object with the dimension name as key and an array of regexes that will be applied to the dimension value as value.
+aws_dimension_select | Optional. Which dimension values to filter. Specify a map from the dimension name to a list of values to select from that dimension.
+aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
@@ -82,14 +82,14 @@ requests (as of Jan 2015), that is around $45 per month. The
 ## Docker Image
 
 To run the CloudWatch exporter on Docker, you can use the [prom/cloudwatch-exporter](https://registry.hub.docker.com/u/prom/cloudwatch-exporter)
-image. It exposes port 9106 and expects the config in `/config.json`. To
+image. It exposes port 9106 and expects the config in `/config.yml`. To
 configure it, you can either bind-mount a config from your host:
 
 ```
-$ docker run -p 9106 -v /path/on/host/config.json:/config.json prom/cloudwatch-exporter
+$ docker run -p 9106 -v /path/on/host/config.yml:/config.yml prom/cloudwatch-exporter
 ```
 
-Or you create a config file named config.json along with following
+Or you create a config file named config.yml along with following
 Dockerfile in the same directory and build it with `docker build`:
 
 ```


### PR DESCRIPTION
It's rather confusing to have config.json containing yaml-formatted text.  This updates the Dockerfile (and the readme) to use config.yml instead.