### PR TITLE
introduce optional role_arn for retrieving cross account metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ metrics:
 Name     | Description
 ---------|------------
 region   | Required. The AWS region to connect to.
+role_arn   | Optional. The AWS role to assume. Useful for retrieving cross account metrics.
 metrics  | Required. A list of CloudWatch metrics to retrieve and export
 aws_namespace  | Required. Namespace of the CloudWatch metric.
 aws_metric_name  | Required. Metric name of the CloudWatch metric.

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
       <version>1.10.34</version>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>1.10.34</version>
+    </dependency>
+    <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>1.17</version>

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -1,5 +1,6 @@
 package io.prometheus.cloudwatch;
 
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.amazonaws.services.cloudwatch.model.Datapoint;
 import com.amazonaws.services.cloudwatch.model.Dimension;
@@ -83,7 +84,15 @@ public class CloudWatchCollector extends Collector {
         }
 
         if (client == null) {
-          this.client = new AmazonCloudWatchClient();
+          if (config.containsKey("role_arn")) {
+            STSAssumeRoleSessionCredentialsProvider credentialsProvider = new STSAssumeRoleSessionCredentialsProvider(
+              (String) config.get("role_arn"),
+              "cloudwatch_exporter"
+            );
+            this.client = new AmazonCloudWatchClient(credentialsProvider);
+          } else {
+            this.client = new AmazonCloudWatchClient();
+          }
           this.client.setEndpoint("https://monitoring." + region + ".amazonaws.com");
         } else {
           this.client = client;


### PR DESCRIPTION
This allows us to start a cloudwatch_exporter which can query metrics from another AWS account.

cc: @bracki


The cloudformation template we use:
```json
{
    "Resources": {
        "GrantReadAccessToAnotherAccount": {
            "Properties": {
                "AssumeRolePolicyDocument": {
                    "Statement": [
                        {
                            "Action": [
                                "sts:AssumeRole"
                            ],
                            "Effect": "Allow",
                            "Principal": {
                                "AWS": [
                                    "arn:aws:iam::YOUR_ACCOUNT_HERE:root"
                                ]
                            }
                        }
                    ],
                    "Version": "2012-10-17"
                },
                "ManagedPolicyArns": [
                    "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
                ]
            },
            "Type": "AWS::IAM::Role"
        }
    }
}

```