### PR TITLE
Support regex in config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN echo 'http://dl-3.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositor
     && apk add maven openjdk8-jre \
     && mvn package \
     && mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar \
-    && rm -rf /cloudwatch_exporter \
-    && apk del maven openjdk8-jre
+    && apk del maven openjdk8-jre \
+    && rm -rf /cloudwatch_exporter
 
 WORKDIR /
 COPY config.yml /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM wehkamp/jre:1.8
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
+LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.0
+
 EXPOSE 9106
 
 WORKDIR /cloudwatch_exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
-FROM wehkamp/jre:1.8
+FROM java
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
-LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.0
-
 EXPOSE 9106
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN echo 'http://dl-3.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
-    && echo 'http://dl-3.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
-    && apk update \
-    && apk add maven openjdk8-jre \
-    && mvn package \
-    && mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar \
-    && apk del maven openjdk8-jre \
-    && rm -rf /cloudwatch_exporter
-
+RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
+    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
+    rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
 WORKDIR /
-ONBUILD COPY config.yml /
-ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]
+
+ONBUILD ADD config.json /
+ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN echo 'http://dl-3.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositor
     && rm -rf /cloudwatch_exporter
 
 WORKDIR /
-COPY config.yml /
+ONBUILD COPY config.yml /
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
     rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
 WORKDIR /
 
-ONBUILD ADD config.json /
-ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.json" ]
+ONBUILD ADD config.yml /
+ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-FROM java
+FROM wehkamp/jre:1.8
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 EXPOSE 9106
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
-    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
-    rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
-WORKDIR /
+RUN echo 'http://dl-3.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
+    && echo 'http://dl-3.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
+    && apk update \
+    && apk add maven openjdk8-jre \
+    && mvn package \
+    && mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar \
+    && rm -rf /cloudwatch_exporter \
+    && apk del maven openjdk8-jre
 
-ONBUILD ADD config.yml /
+WORKDIR /
+COPY config.yml /
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ aws_namespace  | Required. Namespace of the CloudWatch metric.
 aws_metric_name  | Required. Metric name of the CloudWatch metric.
 aws_dimensions | Optional. Which dimension to fan out over.
 aws_dimension_select | Optional. Which dimension values to filter. Specify a map from the dimension name to a list of values to select from that dimension.
-aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension.
+aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension. This also tries to expand environment variables used as value, like ${CLOUDWATCH_REGEX} or even ${TMPDIR}.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -18,8 +18,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Set;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,6 +33,19 @@ public class CloudWatchCollector extends Collector {
     private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
     AmazonCloudWatchClient client; 
+
+    /* Expand all environment variables in text */
+    public static String expandEnvVars(String text) {
+        Map<String, String> envMap = System.getenv();
+        for (Entry<String, String> entry : envMap.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            text = text.replaceAll("\\$\\{" + key + "\\}", value);
+            String message = key + " => " + value + " (" + text + ")";
+            LOGGER.log(Level.FINE, " Expanded k/v: {0}", message);
+        }
+        return text;
+    }
 
     static class MetricRule {
       String awsNamespace;
@@ -124,6 +139,18 @@ public class CloudWatchCollector extends Collector {
           }
           if (yamlMetricRule.containsKey("aws_dimension_select_regex")) {
             rule.awsDimensionSelectRegex = (Map<String,List<String>>)yamlMetricRule.get("aws_dimension_select_regex");
+            // Go over all regexes and try to expand any environment variables.
+            for (Entry<String, List<String>> entry : rule.awsDimensionSelectRegex.entrySet()) {
+              String key = entry.getKey();
+              List<String> values = entry.getValue();
+              LinkedList<String> expandedValues = new LinkedList<String>();
+              for (String value : values) {
+                expandedValues.add(expandEnvVars(value));
+              }
+              String message = "Expanded key " + key + " to value " + expandedValues;
+              LOGGER.log(Level.INFO, " {0}", message);
+              entry.setValue(expandedValues);
+            }
           }
           if (yamlMetricRule.containsKey("aws_statistics")) {
             rule.awsStatistics = (List<String>)yamlMetricRule.get("aws_statistics");


### PR DESCRIPTION
Our use-case requires stateless containers, not backed using static configuration files. Using the environment to specify on which values to match, the operator simply deploys this **one** container to each of our Mesos deployments with some env vars.