### PR TITLE
Add healthcheck to /status route

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/HealthCheckServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthCheckServlet.java
@@ -1,0 +1,38 @@
+package io.prometheus.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class HealthCheckServlet extends HttpServlet {
+    private AmazonCloudWatchClient client;
+
+    public HealthCheckServlet(AmazonCloudWatchClient client) {
+        this.client = client;
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter writer = resp.getWriter();
+        resp.setContentType("text/plain; charset=utf-8");
+        try {
+            this.client.listMetrics();
+            resp.setStatus(200);
+            writer.write("Ok");
+        } catch (com.amazonaws.AmazonClientException e) {
+            resp.setStatus(500);
+            writer.write("Error when connecting to AWS Cloudwatch: " + e.getMessage());
+        } finally {
+            writer.flush();
+            writer.close();
+        }
+    }
+
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        this.doGet(req, resp);
+    }
+}

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -20,6 +20,7 @@ public class WebServer {
      context.setContextPath("/");
      server.setHandler(context);
      context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+     context.addServlet(new ServletHolder(new HealthCheckServlet(cc.client)), "/status");
      server.start();
      server.join();
    }


### PR DESCRIPTION
in order to have a healthcheck endpoint which could be used by a load balancer (eg. AWS ELB).

This avoids that one has to use the /metrics route for a healthcheck, which is very expensive and slow when a lot of metrics are configured to be collected.

PTAL @brian-brazil 