### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.10.34</version>
+      <version>1.11.52</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.10.34</version>
+      <version>1.11.52</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>


### PR DESCRIPTION
update aws sdk to 	1.11.52
https://aws.amazon.com/releasenotes/Java/9979983567247718
does not look like this is using any of the breaking changes described here.

The provided docker image can not be run with ECS without this update due to the way that ECS tasks get their credentials.
Built container locally and verified that tests are passing.