### PR TITLE
Upgrade pom.xml dependencies for proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.11.52</version>
+      <version>1.11.86</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.52</version>
+      <version>1.11.86</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.0.11</version>
+      <version>0.0.20</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.11</version>
+      <version>0.0.20</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.0.20</version>
+      <version>0.0.11</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.20</version>
+      <version>0.0.11</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
I was trying to use this exporter behind an http proxy, and after upgrading the following libraries, I was successfull.

 - com.amazonaws.aws-java-sdk-cloudwatch => 1.11.86
 - com.amazonaws.aws-java-sdk-sts        => 1.11.86
 - io.prometheus.simpleclient            => 0.0.20
 - io.prometheus.simpleclient_servlet    => 0.0.20