### PR TITLE
Avoid generating duplicate help text for DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ In addition `cloudwatch_exporter_scrape_error` will be non-zero if an error
 occurred during the scrape, and `cloudwatch_exporter_scrape_duration_seconds`
 contains the duration of that scrape.
 
+### Metrics for DynamoDB Global Secondary Indexes
+
+CloudWatch exposes some DynamoDB metrics with the same names in both the
+TableName and TableName + GlobalSecondaryIndexName dimensions. These metrics
+require special handling to avoid exporting duplicate HELP and and TYPE lines
+in the case where the exporter is configured to retrieve metrics for both tables
+and indexes.
+
+When exporting one of the problematic metrics listed below for an index the
+exporter will use a metric name in the format `aws_dynamodb_METRIC_index_STATISTIC`
+rather than the usual `aws_dynamodb_METRIC_STATISTIC`.
+
+ * ConsumedReadCapacityUnits
+ * ConsumedWriteCapacityUnits
+ * ProvisionedReadCapacityUnits
+ * ProvisionedWriteCapacityUnits
+ * ReadThrottleEvents
+ * WriteThrottleEvents
+
 ### Cost
 
 Amazon charges for every API request, see the [current charges](http://aws.amazon.com/cloudwatch/pricing/).

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -315,6 +315,15 @@ public class CloudWatchCollector extends Collector {
 
         String unit = null;
 
+        if (rule.awsNamespace.equals("AWS/DynamoDB") && rule.awsDimensions.contains("GlobalSecondaryIndexName")) {
+            /*
+             * Cloudwatch provides DynamoDB metrics with the same names but different meanings in
+             * both the [TableName] and [TableName, GlobalSecondaryIndexName] dimensions for the
+             * AWS/DynamoDB namespace. Without special handling this results in duplicate HELP text.
+             */
+            baseName += "_index";
+        }
+
         for (List<Dimension> dimensions: getDimensions(rule)) {
           request.setDimensions(dimensions);
 

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -322,4 +322,30 @@ public class CloudWatchCollectorTest {
     assertEquals(1.0, registry.getSampleValue("aws_elb_latency_p95", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
     assertEquals(2.0, registry.getSampleValue("aws_elb_latency_p99_99", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
   }
+
+  @Test
+  public void testDynamoIndexDimensions() throws Exception {
+    new CloudWatchCollector(
+        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: ConsumedReadCapacityUnits\n  aws_dimensions:\n  - TableName\n  - GlobalSecondaryIndexName\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: ConsumedReadCapacityUnits\n  aws_dimensions:\n  - TableName", client).register(registry);
+    Mockito.when(client.listMetrics((ListMetricsRequest)argThat(
+        new ListMetricsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimensions("TableName", "GlobalSecondaryIndexName"))))
+        .thenReturn(new ListMetricsResult().withMetrics(
+          new Metric().withDimensions(new Dimension().withName("TableName").withValue("myTable"), new Dimension().withName("GlobalSecondaryIndexName").withValue("myIndex"))));
+    Mockito.when(client.listMetrics((ListMetricsRequest)argThat(
+        new ListMetricsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimensions("TableName"))))
+        .thenReturn(new ListMetricsResult().withMetrics(
+          new Metric().withDimensions(new Dimension().withName("TableName").withValue("myTable"))));
+
+    Mockito.when(client.getMetricStatistics((GetMetricStatisticsRequest)argThat(
+        new GetMetricStatisticsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimension("TableName", "myTable").Dimension("GlobalSecondaryIndexName", "myIndex"))))
+        .thenReturn(new GetMetricStatisticsResult().withDatapoints(
+            new Datapoint().withTimestamp(new Date()).withSum(2.0)));
+    Mockito.when(client.getMetricStatistics((GetMetricStatisticsRequest)argThat(
+        new GetMetricStatisticsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimension("TableName", "myTable"))))
+        .thenReturn(new GetMetricStatisticsResult().withDatapoints(
+            new Datapoint().withTimestamp(new Date()).withSum(3.0)));
+
+    assertEquals(2.0, registry.getSampleValue("aws_dynamodb_consumed_read_capacity_units_index_sum", new String[]{"job", "instance", "table_name", "global_secondary_index_name"}, new String[]{"aws_dynamodb", "", "myTable", "myIndex"}), .01);
+    assertEquals(3.0, registry.getSampleValue("aws_dynamodb_consumed_read_capacity_units_sum", new String[]{"job", "instance", "table_name"}, new String[]{"aws_dynamodb", "", "myTable"}), .01);
+  }
 }


### PR DESCRIPTION
This is my attempt at fixing the issue described in #18. I'm not too experienced with Java, so please let me know if anything looks stupid and I'll fix it up.

As was suggested in the linked issue this modifies `baseName` when scraping metrics from AWS/DynamoDB and fanning out across the GlobalSecondaryIndexName namespace.

That is, given a config.yaml like the below

```yaml
---
region: us-east-1
metrics:
 - aws_namespace: AWS/DynamoDB
   aws_metric_name: ConsumedReadCapacityUnits
   aws_dimensions: [TableName, GlobalSecondaryIndexName]
   aws_dimension_select:
     TableName: ["my-test-table"]
   aws_statistics: [Sum]
 - aws_namespace: AWS/DynamoDB
   aws_metric_name: ConsumedReadCapacityUnits
   aws_dimensions: [TableName]
   aws_dimension_select:
     TableName: ["my-test-table"]
   aws_statistics: [Sum]
```

a scrape will produce the following metrics

```
# HELP aws_dynamodb_consumed_read_capacity_units_index_sum CloudWatch metric AWS/DynamoDB ConsumedReadCapacityUnits Dimensions: [TableName, GlobalSecondaryIndexName] Statistic: Sum Unit: Count
# TYPE aws_dynamodb_consumed_read_capacity_units_index_sum gauge
aws_dynamodb_consumed_read_capacity_units_index_sum{job="aws_dynamodb",instance="",table_name="my-test-table",global_secondary_index_name="my-test-index",} 123.4
# HELP aws_dynamodb_consumed_read_capacity_units_sum CloudWatch metric AWS/DynamoDB ConsumedReadCapacityUnits Dimensions: [TableName] Statistic: Sum Unit: Count
# TYPE aws_dynamodb_consumed_read_capacity_units_sum gauge
aws_dynamodb_consumed_read_capacity_units_sum{job="aws_dynamodb",instance="",table_name="my-test-table",} 456.7
```

I'm not 100% certain about the metric name, `aws_dynamodb_METRIC_index_STATISTIC` vs `aws_dynamodb_METRIC_STATISTIC`. Perhaps `aws_dynamodb_index_METRIC_STATISTIC` would be better, or something else entirely?

If anyone is currently sidestepping this issue by running a separate instance of the exporter for index metrics then they'll have the metric names changed under them if they upgrade. We might want to call that out if we decide to merge this. 

Finally, I'm aware of one other case similar to DynamoDB. The [Kinesis Client Library](https://github.com/awslabs/amazon-kinesis-client) will [publish Cloudwatch metrics](http://docs.aws.amazon.com/streams/latest/dev/monitoring-with-kcl.html) with useful names like `Time` and `Success` with what I believe are different meanings in different sets of dimensions. Since this tool isn't ideal for extracting KCL metrics (each KCL application will create its own _namespace_) we can probably just ignore it for now.