### PR TITLE
Add support for Cloudwatch extended statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ aws_metric_name  | Required. Metric name of the CloudWatch metric.
 aws_dimensions | Optional. Which dimension to fan out over.
 aws_dimension_select | Optional. Which dimension values to filter. Specify a map from the dimension name to a list of values to select from that dimension.
 aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension.
-aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics.
+aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics unless extended statistics are requested.
+aws_extended_statistics | Optional. A list of extended statistics to retrieve. Extended statistics currently include percentiles in the form `pN` or `pN.N`.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -43,6 +43,7 @@ public class CloudWatchCollector extends Collector {
       int rangeSeconds;
       int delaySeconds;
       List<String> awsStatistics;
+      List<String> awsExtendedStatistics;
       List<String> awsDimensions;
       Map<String,List<String>> awsDimensionSelect;
       Map<String,List<String>> awsDimensionSelectRegex;
@@ -132,8 +133,11 @@ public class CloudWatchCollector extends Collector {
           }
           if (yamlMetricRule.containsKey("aws_statistics")) {
             rule.awsStatistics = (List<String>)yamlMetricRule.get("aws_statistics");
-          } else {
+          } else if (!yamlMetricRule.containsKey("aws_extended_statistics")) {
             rule.awsStatistics = new ArrayList(Arrays.asList("Sum", "SampleCount", "Minimum", "Maximum", "Average"));
+          }
+          if (yamlMetricRule.containsKey("aws_extended_statistics")) {
+            rule.awsExtendedStatistics = (List<String>)yamlMetricRule.get("aws_extended_statistics");
           }
           if (yamlMetricRule.containsKey("period_seconds")) {
             rule.periodSeconds = ((Number)yamlMetricRule.get("period_seconds")).intValue();
@@ -295,6 +299,7 @@ public class CloudWatchCollector extends Collector {
         request.setNamespace(rule.awsNamespace);
         request.setMetricName(rule.awsMetricName);
         request.setStatistics(rule.awsStatistics);
+        request.setExtendedStatistics(rule.awsExtendedStatistics);
         request.setEndTime(startDate);
         request.setStartTime(endDate);
         request.setPeriod(rule.periodSeconds);
@@ -306,6 +311,7 @@ public class CloudWatchCollector extends Collector {
         List<MetricFamilySamples.Sample> minimumSamples = new ArrayList<MetricFamilySamples.Sample>();
         List<MetricFamilySamples.Sample> maximumSamples = new ArrayList<MetricFamilySamples.Sample>();
         List<MetricFamilySamples.Sample> averageSamples = new ArrayList<MetricFamilySamples.Sample>();
+        HashMap<String, ArrayList<MetricFamilySamples.Sample>> extendedSamples = new HashMap<String, ArrayList<MetricFamilySamples.Sample>>();
 
         String unit = null;
 
@@ -351,6 +357,17 @@ public class CloudWatchCollector extends Collector {
             averageSamples.add(new MetricFamilySamples.Sample(
                 baseName + "_average", labelNames, labelValues, dp.getAverage()));
           }
+          if (dp.getExtendedStatistics() != null) {
+            for (Map.Entry<String, Double> entry : dp.getExtendedStatistics().entrySet()) {
+              ArrayList<MetricFamilySamples.Sample> samples = extendedSamples.get(entry.getKey());
+              if (samples == null) {
+                samples = new ArrayList<MetricFamilySamples.Sample>();
+                extendedSamples.put(entry.getKey(), samples);
+              }
+              samples.add(new MetricFamilySamples.Sample(
+                  baseName + "_" + entry.getKey(), labelNames, labelValues, entry.getValue()));
+            }
+          }
         }
 
         if (!sumSamples.isEmpty()) {
@@ -367,6 +384,9 @@ public class CloudWatchCollector extends Collector {
         }
         if (!averageSamples.isEmpty()) {
           mfs.add(new MetricFamilySamples(baseName + "_average", Type.GAUGE, help(rule, unit, "Average"), averageSamples));
+        }
+        for (Map.Entry<String, ArrayList<MetricFamilySamples.Sample>> entry : extendedSamples.entrySet()) {
+          mfs.add(new MetricFamilySamples(baseName + "_" + entry.getKey(), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
         }
       }
     }

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -365,7 +365,7 @@ public class CloudWatchCollector extends Collector {
                 extendedSamples.put(entry.getKey(), samples);
               }
               samples.add(new MetricFamilySamples.Sample(
-                  baseName + "_" + entry.getKey(), labelNames, labelValues, entry.getValue()));
+                  baseName + "_" + safeName(toSnakeCase(entry.getKey())), labelNames, labelValues, entry.getValue()));
             }
           }
         }
@@ -386,7 +386,7 @@ public class CloudWatchCollector extends Collector {
           mfs.add(new MetricFamilySamples(baseName + "_average", Type.GAUGE, help(rule, unit, "Average"), averageSamples));
         }
         for (Map.Entry<String, ArrayList<MetricFamilySamples.Sample>> entry : extendedSamples.entrySet()) {
-          mfs.add(new MetricFamilySamples(baseName + "_" + entry.getKey(), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
+          mfs.add(new MetricFamilySamples(baseName + "_" + safeName(toSnakeCase(entry.getKey())), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
         }
       }
     }

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -320,6 +320,6 @@ public class CloudWatchCollectorTest {
             new Datapoint().withTimestamp(new Date()).withExtendedStatistics(extendedStatistics)));
 
     assertEquals(1.0, registry.getSampleValue("aws_elb_latency_p95", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_latency_p99.99", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
+    assertEquals(2.0, registry.getSampleValue("aws_elb_latency_p99_99", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
   }
 }


### PR DESCRIPTION
This adds support for [extended statistics](https://aws.amazon.com/blogs/aws/amazon-cloudwatch-update-percentile-statistics-and-new-dashboard-widgets/), which can be used to obtain percentile values for certain Cloudwatch metrics.

A config such as

```yaml
---
region: us-east-1
metrics:
 - aws_namespace: AWS/ELB
   aws_metric_name: Latency
   aws_dimensions: [LoadBalancerName]
   aws_dimension_select:
     LoadBalancerName: ["my-test-elb"]
   aws_extended_statistics: ["p95", "p99.99"]
```

will result in

```
# HELP aws_elb_latency_p99.99 CloudWatch metric AWS/ELB Latency Dimensions: [LoadBalancerName] Statistic: p99.99 Unit: Seconds
# TYPE aws_elb_latency_p99.99 gauge
aws_elb_latency_p99.99{job="aws_elb",instance="",load_balancer_name="my-test-elb",} 1.883888000527654
# HELP aws_elb_latency_p95 CloudWatch metric AWS/ELB Latency Dimensions: [LoadBalancerName] Statistic: p95 Unit: Seconds
# TYPE aws_elb_latency_p95 gauge
aws_elb_latency_p95{job="aws_elb",instance="",load_balancer_name="my-test-elb",} 0.20261543373300783
```

Some notes on implementation:

 * I've exposed the underlying API more or less directly. It requires that extended statistics be requested via a separate parameter. Another option would be for the exporter to expect a config with both regular and extended statistics in the same array and to split them apart at scrape time. That would remove the need for the default value of `aws_statistics` to depend on `aws_extended_statistics` but doesn't otherwise seem worthwhile.
 * The current version adds the extended statistic name to the metric name verbatim. Happy to update it to convert the period to an underscore if that's preferred.