### PR TITLE
Use /config/config.yml because it is more friendly to kubernetes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
     rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
 WORKDIR /
 
-ONBUILD ADD config.yml /
-ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]
+RUN mkdir /config
+
+ONBUILD ADD config.yml /config/
+ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config/config.yml" ]

--- a/README.md
+++ b/README.md
@@ -117,10 +117,6 @@ configure it, you can either bind-mount a config from your host:
 $ docker run -p 9106 -v /path/on/host/config.yml:/config/config.yml prom/cloudwatch-exporter
 ```
 
-Why run in /config/config.yml instead of /config.yml?  Because in kubernetes 
-(a fellow CNCF project) you cannot mount a configmap (the standard way of 
-defining your config) on / and only in a directory.
-
 Or you create a config file named /config/config.yml along with following
 Dockerfile in the same directory and build it with `docker build`:
 

--- a/README.md
+++ b/README.md
@@ -110,14 +110,18 @@ requests (as of Jan 2015), that is around $45 per month. The
 ## Docker Image
 
 To run the CloudWatch exporter on Docker, you can use the [prom/cloudwatch-exporter](https://hub.docker.com/r/prom/cloudwatch-exporter/)
-image. It exposes port 9106 and expects the config in `/config.yml`. To
+image. It exposes port 9106 and expects the config in `/config/config.yml`. To
 configure it, you can either bind-mount a config from your host:
 
 ```
-$ docker run -p 9106 -v /path/on/host/config.yml:/config.yml prom/cloudwatch-exporter
+$ docker run -p 9106 -v /path/on/host/config.yml:/config/config.yml prom/cloudwatch-exporter
 ```
 
-Or you create a config file named config.yml along with following
+Why run in /config/config.yml instead of /config.yml?  Because in kubernetes 
+(a fellow CNCF project) you cannot mount a configmap (the standard way of 
+defining your config) on / and only in a directory.
+
+Or you create a config file named /config/config.yml along with following
 Dockerfile in the same directory and build it with `docker build`:
 
 ```


### PR DESCRIPTION
as per https://github.com/prometheus/cloudwatch_exporter/issues/67 and https://github.com/prometheus/cloudwatch_exporter/issues/54