### PR TITLE
Configuration reload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ DynamoDB metrics not listed above.
 There are two ways to reload configuration:
 
 1. Send a SIGHUP signal to the pid: `kill -HUP 1234`
-2. POST to the `reload` endpoint: `curl -X localhost:9107/-/reload`
+2. POST to the `reload` endpoint: `curl -X localhost:9106/-/reload`
 
-If an error occurs during the reload, see check the exporter's log output.
+If an error occurs during the reload, check the exporter's log output.
 
 ### Cost
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ the usual `aws_dynamodb_METRIC_STATISTIC`. The regular naming scheme will still
 be used when exporting these metrics for a table, and when exporting any other
 DynamoDB metrics not listed above.
 
+### Reloading Configuration
+
+There are two ways to reload configuration:
+
+1. Send a SIGHUP signal to the pid: `kill -HUP 1234`
+2. POST to the `reload` endpoint: `curl -X localhost:9107/-/reload`
+
+If an error occurs during the reload, see check the exporter's log output.
+
 ### Cost
 
 Amazon charges for every API request, see the [current charges](http://aws.amazon.com/cloudwatch/pricing/).

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -14,6 +14,8 @@ import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
 import com.amazonaws.services.cloudwatch.model.Metric;
 import io.prometheus.client.Collector;
 import io.prometheus.client.Counter;
+
+import java.io.FileReader;
 import java.io.Reader;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -89,13 +91,15 @@ public class CloudWatchCollector extends Collector {
         }
     }
 
-    protected void loadConfig(Reader in) throws IOException {
-        loadConfig(in, getClient());
+    protected void reloadConfig() throws IOException {
+        LOGGER.log(Level.INFO, "Reloading configuration");
+
+        loadConfig(new FileReader(WebServer.configFilePath), getClient());
     }
+
     protected void loadConfig(Reader in, AmazonCloudWatchClient client) throws IOException {
         loadConfig((Map<String, Object>)new Yaml().load(in), client);
     }
-
     private void loadConfig(Map<String, Object> config, AmazonCloudWatchClient client) {
         if(config == null) {  // Yaml config empty, set config to empty map.
             config = new HashMap<String, Object>();

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -61,7 +61,7 @@ public class CloudWatchCollector extends Collector {
     ArrayList<MetricRule> rules = new ArrayList<MetricRule>();
 
     public CloudWatchCollector(Reader in) throws IOException {
-        this((Map<String, Object>)new Yaml().load(in),null);
+        loadConfig(in, null);
     }
     public CloudWatchCollector(String yamlConfig) {
         this((Map<String, Object>)new Yaml().load(yamlConfig),null);
@@ -73,6 +73,20 @@ public class CloudWatchCollector extends Collector {
     }
 
     private CloudWatchCollector(Map<String, Object> config, AmazonCloudWatchClient client) {
+        loadConfig(config, client);
+    }
+
+    protected void reloadConfig(Reader in) throws IOException {
+        this.rules.clear();
+        this.region = null;
+
+        loadConfig(in, this.client);
+    }
+    protected void loadConfig(Reader in, AmazonCloudWatchClient client) throws IOException {
+        loadConfig((Map<String, Object>)new Yaml().load(in), client);
+    }
+
+    private void loadConfig(Map<String, Object> config, AmazonCloudWatchClient client) {
         if(config == null) {  // Yaml config empty, set config to empty map.
             config = new HashMap<String, Object>(); 
         }

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -188,7 +188,7 @@ public class CloudWatchCollector extends Collector {
         setRules(rules);
     }
 
-    private String getMonitoringEndpoint(Region region) {
+    public String getMonitoringEndpoint(Region region) {
       return "https://" + region.getServiceEndpoint("monitoring");
     }
 

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -26,7 +26,7 @@ public class DynamicReloadServlet extends HttpServlet {
 
         this.collector.loadConfig(new FileReader(this.configFilePath));
 
-        resp.setContentType("text/html");
+        resp.setContentType("text/plain");
         resp.getWriter().print("OK");
     }
 }

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -1,0 +1,33 @@
+package io.prometheus.cloudwatch;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class DynamicReloadServlet extends HttpServlet {
+
+    private static CloudWatchCollector collector;
+    private static String configFilePath;
+
+    private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+
+    public DynamicReloadServlet(CloudWatchCollector cc, String path) {
+        this.collector = cc;
+        this.configFilePath = path;
+    }
+
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        LOGGER.log(Level.INFO, "Reloading configuration file");
+
+        this.collector.reloadConfig(new FileReader(this.configFilePath));
+
+        resp.setContentType("text/html");
+        resp.getWriter().print("OK");
+    }
+}

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -10,6 +10,11 @@ import java.util.logging.Logger;
 
 public class DynamicReloadServlet extends HttpServlet {
     private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+    private static CloudWatchCollector collector;
+
+    public DynamicReloadServlet(CloudWatchCollector collector) {
+        this.collector = collector;
+    }
 
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setStatus(405);
@@ -18,7 +23,7 @@ public class DynamicReloadServlet extends HttpServlet {
     }
 
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        WebServer.collector.reloadConfig();
+        collector.reloadConfig();
 
         resp.setContentType("text/plain");
         resp.getWriter().print("OK");

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -4,27 +4,17 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class DynamicReloadServlet extends HttpServlet {
-
-    private static CloudWatchCollector collector;
-    private static String configFilePath;
-
     private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
-    public DynamicReloadServlet(CloudWatchCollector cc, String path) {
-        this.collector = cc;
-        this.configFilePath = path;
     }
 
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        LOGGER.log(Level.INFO, "Reloading configuration file");
-
-        this.collector.loadConfig(new FileReader(this.configFilePath));
+        WebServer.collector.reloadConfig();
 
         resp.setContentType("text/plain");
         resp.getWriter().print("OK");

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -11,6 +11,10 @@ import java.util.logging.Logger;
 public class DynamicReloadServlet extends HttpServlet {
     private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(405);
+        resp.setContentType("text/plain");
+        resp.getWriter().print("Only POST requests allowed");
     }
 
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -6,7 +6,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,7 +24,7 @@ public class DynamicReloadServlet extends HttpServlet {
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         LOGGER.log(Level.INFO, "Reloading configuration file");
 
-        this.collector.reloadConfig(new FileReader(this.configFilePath));
+        this.collector.loadConfig(new FileReader(this.configFilePath));
 
         resp.setContentType("text/html");
         resp.getWriter().print("OK");

--- a/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
+++ b/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
@@ -1,0 +1,23 @@
+package io.prometheus.cloudwatch;
+
+import io.prometheus.cloudwatch.WebServer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
+class ReloadSignalHandler {
+    private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+
+    protected static void start() {
+        Signal.handle(new Signal("HUP"), new SignalHandler() {
+            public void handle(Signal signal) {
+                try {
+                    WebServer.collector.reloadConfig();
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Configuration reload failed", e);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
+++ b/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
@@ -8,11 +8,11 @@ import sun.misc.SignalHandler;
 class ReloadSignalHandler {
     private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
-    protected static void start() {
+    protected static void start(final CloudWatchCollector collector) {
         Signal.handle(new Signal("HUP"), new SignalHandler() {
             public void handle(Signal signal) {
                 try {
-                    WebServer.collector.reloadConfig();
+                    collector.reloadConfig();
                 } catch (Exception e) {
                     LOGGER.log(Level.WARNING, "Configuration reload failed", e);
                 }

--- a/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
+++ b/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
@@ -1,6 +1,5 @@
 package io.prometheus.cloudwatch;
 
-import io.prometheus.cloudwatch.WebServer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import sun.misc.Signal;

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -2,27 +2,41 @@ package io.prometheus.cloudwatch;
 
 import io.prometheus.client.exporter.MetricsServlet;
 import java.io.FileReader;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 public class WebServer {
-   public static void main(String[] args) throws Exception {
-     if (args.length < 2) {
-       System.err.println("Usage: WebServer <port> <yml configuration file>");
-       System.exit(1);
-     }
-     CloudWatchCollector cc = new CloudWatchCollector(new FileReader(args[1])).register();
 
-     int port = Integer.parseInt(args[0]);
-     Server server = new Server(port);
-     ServletContextHandler context = new ServletContextHandler();
-     context.setContextPath("/");
-     server.setHandler(context);
-     context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-     context.addServlet(new ServletHolder(new DynamicReloadServlet(cc, args[1])), "/-/reload");
-     context.addServlet(new ServletHolder(new HomePageServlet()), "/");
-     server.start();
-     server.join();
-   }
+    public static String configFilePath;
+    public static CloudWatchCollector collector;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("Usage: WebServer <port> <yml configuration file>");
+            System.exit(1);
+        }
+
+        configFilePath = args[1];
+        collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
+
+        ReloadSignalHandler.start();
+
+        int port = Integer.parseInt(args[0]);
+        Server server = new Server(port);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        server.setHandler(context);
+        context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+        context.addServlet(new ServletHolder(new DynamicReloadServlet()), "/-/reload");
+        context.addServlet(new ServletHolder(new HomePageServlet()), "/");
+        server.start();
+        server.join();
+    }
 }
+

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -14,7 +14,6 @@ import sun.misc.SignalHandler;
 public class WebServer {
 
     public static String configFilePath;
-    public static CloudWatchCollector collector;
 
     public static void main(String[] args) throws Exception {
         if (args.length < 2) {
@@ -23,9 +22,9 @@ public class WebServer {
         }
 
         configFilePath = args[1];
-        collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
+        CloudWatchCollector collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
 
-        ReloadSignalHandler.start();
+        ReloadSignalHandler.start(collector);
 
         int port = Integer.parseInt(args[0]);
         Server server = new Server(port);
@@ -33,7 +32,7 @@ public class WebServer {
         context.setContextPath("/");
         server.setHandler(context);
         context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-        context.addServlet(new ServletHolder(new DynamicReloadServlet()), "/-/reload");
+        context.addServlet(new ServletHolder(new DynamicReloadServlet(collector)), "/-/reload");
         context.addServlet(new ServletHolder(new HomePageServlet()), "/");
         server.start();
         server.join();

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -20,6 +20,7 @@ public class WebServer {
      context.setContextPath("/");
      server.setHandler(context);
      context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+     context.addServlet(new ServletHolder(new DynamicReloadServlet(cc, args[1])), "/-/reload");
      context.addServlet(new ServletHolder(new HomePageServlet()), "/");
      server.start();
      server.join();

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -297,15 +297,6 @@ public class CloudWatchCollectorTest {
   }
 
   @Test
-  public void testGetMonitoringEndpoint() throws Exception {
-    CloudWatchCollector us_collector = new CloudWatchCollector("---\nregion: us-east-1\nmetrics: []\n");
-    assertEquals("https://monitoring.us-east-1.amazonaws.com", us_collector.getMonitoringEndpoint());
-
-    CloudWatchCollector cn_collector = new CloudWatchCollector("---\nregion: cn-north-1\nmetrics: []\n");
-    assertEquals("https://monitoring.cn-north-1.amazonaws.com.cn", cn_collector.getMonitoringEndpoint());
-  }
-
-  @Test
   public void testExtendedStatistics() throws Exception {
     new CloudWatchCollector(
         "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: Latency\n  aws_extended_statistics:\n  - p95\n  - p99.99", client).register(registry);

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.argThat;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.amazonaws.services.cloudwatch.model.Datapoint;
 import com.amazonaws.services.cloudwatch.model.Dimension;
@@ -294,6 +296,17 @@ public class CloudWatchCollectorTest {
             new Datapoint().withTimestamp(new Date()).withAverage(2.0)));
 
     assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
+  }
+
+  @Test
+  public void testGetMonitoringEndpoint() throws Exception {
+    Region usEast = RegionUtils.getRegion("us-east-1");
+    CloudWatchCollector us_collector = new CloudWatchCollector("---\nregion: us-east-1\nmetrics: []\n");
+    assertEquals("https://monitoring.us-east-1.amazonaws.com", us_collector.getMonitoringEndpoint(usEast));
+
+    Region cnNorth = RegionUtils.getRegion("cn-north-1");
+    CloudWatchCollector cn_collector = new CloudWatchCollector("---\nregion: cn-north-1\nmetrics: []\n");
+    assertEquals("https://monitoring.cn-north-1.amazonaws.com.cn", cn_collector.getMonitoringEndpoint(cnNorth));
   }
 
   @Test


### PR DESCRIPTION
Adds an endpoint to dynamically reload the yaml configuration via `curl -X POST localhost:9106/-/reload`.

The `rules` list is now wrapped in a `synchronized` block for consistent object access during updates.