### PR TITLE
Add timestamps to exported metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ aws_elb_request_count_sum{job="aws_elb",load_balancer_name="myotherlb",availabil
 
 All metrics are exported as gauges.
 
-Timestamps from CloudWatch are not passed to Prometheus, pending resolution of
-[#398](https://github.com/prometheus/prometheus/issues/398). CloudWatch has
-been observed to sometimes take minutes for reported values to converge. The
+CloudWatch has been observed to sometimes take minutes for reported values to converge. The
 default `delay_seconds` will result in data that is at least 10 minutes old
-being requested to mitigate this.
+being requested to mitigate this. The samples exposed will have the timestamps of the
+data from CloudWatch, so usual staleness semantics will not apply and values will persist
+for 5m for instant vectors.
 
 In addition `cloudwatch_exporter_scrape_error` will be non-zero if an error
 occurred during the scrape, and `cloudwatch_exporter_scrape_duration_seconds`

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.0.21</version>
+      <version>0.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.21</version>
+      <version>0.4.0</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -383,23 +383,23 @@ public class CloudWatchCollector extends Collector {
 
           if (dp.getSum() != null) {
             sumSamples.add(new MetricFamilySamples.Sample(
-                baseName + "_sum", labelNames, labelValues, dp.getSum()));
+                baseName + "_sum", labelNames, labelValues, dp.getSum(), dp.getTimestamp().getTime()));
           }
           if (dp.getSampleCount() != null) {
             sampleCountSamples.add(new MetricFamilySamples.Sample(
-                baseName + "_sample_count", labelNames, labelValues, dp.getSampleCount()));
+                baseName + "_sample_count", labelNames, labelValues, dp.getSampleCount(), dp.getTimestamp().getTime()));
           }
           if (dp.getMinimum() != null) {
             minimumSamples.add(new MetricFamilySamples.Sample(
-                baseName + "_minimum", labelNames, labelValues, dp.getMinimum()));
+                baseName + "_minimum", labelNames, labelValues, dp.getMinimum(), dp.getTimestamp().getTime()));
           }
           if (dp.getMaximum() != null) {
             maximumSamples.add(new MetricFamilySamples.Sample(
-                baseName + "_maximum",labelNames, labelValues, dp.getMaximum()));
+                baseName + "_maximum",labelNames, labelValues, dp.getMaximum(), dp.getTimestamp().getTime()));
           }
           if (dp.getAverage() != null) {
             averageSamples.add(new MetricFamilySamples.Sample(
-                baseName + "_average", labelNames, labelValues, dp.getAverage()));
+                baseName + "_average", labelNames, labelValues, dp.getAverage(), dp.getTimestamp().getTime()));
           }
           if (dp.getExtendedStatistics() != null) {
             for (Map.Entry<String, Double> entry : dp.getExtendedStatistics().entrySet()) {
@@ -409,7 +409,7 @@ public class CloudWatchCollector extends Collector {
                 extendedSamples.put(entry.getKey(), samples);
               }
               samples.add(new MetricFamilySamples.Sample(
-                  baseName + "_" + safeName(toSnakeCase(entry.getKey())), labelNames, labelValues, entry.getValue()));
+                  baseName + "_" + safeName(toSnakeCase(entry.getKey())), labelNames, labelValues, entry.getValue(), dp.getTimestamp().getTime()));
             }
           }
         }


### PR DESCRIPTION
Hello!

Here are timestamps for displaying delayed cloudwatch metrics in prometheus correctly.
This patch was deployed to our environment and it works. https://github.com/prometheus/cloudwatch_exporter/issues/22
