### PR TITLE
Toggle Cloudwatch timestamps on a per-metric basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ aws_extended_statistics | Optional. A list of extended statistics to retrieve. E
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
-cloudwatch_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
+set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
 
 The above config will export time series such as 
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ aws_extended_statistics | Optional. A list of extended statistics to retrieve. E
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
+cloudwatch_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
 
 The above config will export time series such as 
 ```

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -116,8 +116,8 @@ public class CloudWatchCollector extends Collector {
         }
 
         boolean defaultCloudwatchTimestamp = true;
-        if (config.containsKey("cloudwatch_timestamp")) {
-            defaultCloudwatchTimestamp = (Boolean)config.get("cloudwatch_timestamp");
+        if (config.containsKey("set_timestamp")) {
+            defaultCloudwatchTimestamp = (Boolean)config.get("set_timestamp");
         }
 
         if (client == null) {
@@ -187,8 +187,8 @@ public class CloudWatchCollector extends Collector {
           } else {
             rule.delaySeconds = defaultDelay;
           }
-          if (yamlMetricRule.containsKey("cloudwatch_timestamp")) {
-              rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("cloudwatch_timestamp");
+          if (yamlMetricRule.containsKey("set_timestamp")) {
+              rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("set_timestamp");
           } else {
               rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
           }

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -392,7 +392,7 @@ public class CloudWatchCollector extends Collector {
             labelValues.add(d.getValue());
           }
 
-          long timestamp = 0;
+          Long timestamp = null;
           if (rule.cloudwatchTimestamp) {
             timestamp = dp.getTimestamp().getTime();
           }

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -18,12 +18,21 @@ import com.amazonaws.services.cloudwatch.model.Metric;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 
-import java.util.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 public class CloudWatchCollectorTest {
   AmazonCloudWatchClient client;
@@ -184,7 +193,7 @@ public class CloudWatchCollectorTest {
   @Test
   public void testCloudwatchTimestamps() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  cloudwatch_timestamp: true\n- aws_namespace: AWS/ELB\n  aws_metric_name: HTTPCode_Backend_2XX\n  cloudwatch_timestamp: false"
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  set_timestamp: true\n- aws_namespace: AWS/ELB\n  aws_metric_name: HTTPCode_Backend_2XX\n  set_timestamp: false"
             , client).register(registry);
 
     Date timestamp = new Date();

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -199,11 +199,11 @@ public class CloudWatchCollectorTest {
                     new Datapoint().withTimestamp(timestamp).withAverage(1.0)));
 
     assertMetricTimestampEquals(registry, "aws_elb_request_count_average", timestamp.getTime());
-    assertMetricTimestampEquals(registry, "aws_elb_httpcode_backend_2_xx_average", 0);
+    assertMetricTimestampEquals(registry, "aws_elb_httpcode_backend_2_xx_average", null);
 
   }
 
-  void assertMetricTimestampEquals(CollectorRegistry registry, String name, long expectedTimestamp) {
+  void assertMetricTimestampEquals(CollectorRegistry registry, String name, Long expectedTimestamp) {
     Enumeration<Collector.MetricFamilySamples> metricFamilySamplesEnumeration = registry.metricFamilySamples();
     Set<String> metricNames = new HashSet<String>();
     while(metricFamilySamplesEnumeration.hasMoreElements()) {
@@ -211,7 +211,7 @@ public class CloudWatchCollectorTest {
       for(Collector.MetricFamilySamples.Sample s: samples.samples) {
         metricNames.add(s.name);
         if(s.name.equals(name)) {
-          assertEquals(expectedTimestamp, (long)s.timestampMs);
+          assertEquals(expectedTimestamp, (Long)s.timestampMs);
           return;
         }
       }


### PR DESCRIPTION
Resolves #100 by allowing users to configure whether Cloudwatch timestamps are sent with metrics

Have tested locally and in our own environment 👍 