### PR TITLE
Add CloudFront examples

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -141,6 +141,7 @@ metrics:
   aws_dimensions: [NodeID, ClusterIdentifier]
   aws_statistics: [Average]
 
+# For CloudFront metrics, you have to set the region to us-east-1 
 - aws_namespace: AWS/CloudFront
   aws_metric_name: Requests
   aws_statistics: [Sum]

--- a/example.yml
+++ b/example.yml
@@ -141,7 +141,7 @@ metrics:
   aws_dimensions: [NodeID, ClusterIdentifier]
   aws_statistics: [Average]
 
-# For CloudFront metrics, you have to set the region to us-east-1 
+# For CloudFront metrics, you have to set the region to us-east-1
 - aws_namespace: AWS/CloudFront
   aws_metric_name: Requests
   aws_statistics: [Sum]

--- a/example.yml
+++ b/example.yml
@@ -140,3 +140,45 @@ metrics:
   aws_metric_name: WriteIOPS
   aws_dimensions: [NodeID, ClusterIdentifier]
   aws_statistics: [Average]
+
+- aws_namespace: AWS/CloudFront
+  aws_metric_name: Requests
+  aws_statistics: [Sum]
+  aws_dimensions: [DistributionId, Region]
+  aws_dimensions_select:
+   Region: [Global]
+
+- aws_namespace: AWS/CloudFront
+  aws_metric_name: BytesDownloaded
+  aws_statistics: [Sum]
+  aws_dimensions: [DistributionId, Region]
+  aws_dimensions_select:
+   Region: [Global]
+
+- aws_namespace: AWS/CloudFront
+  aws_metric_name: 4xxErrorRate
+  aws_statistics: [Average]
+  aws_dimensions: [DistributionId, Region]
+  aws_dimensions_select:
+   Region: [Global]
+
+- aws_namespace: AWS/CloudFront
+  aws_metric_name: 5xxErrorRate
+  aws_statistics: [Average]
+  aws_dimensions: [DistributionId, Region]
+  aws_dimensions_select:
+   Region: [Global]
+
+- aws_namespace: AWS/CloudFront
+  aws_metric_name: BytesUploaded
+  aws_statistics: [Sum]
+  aws_dimensions: [DistributionId, Region]
+  aws_dimensions_select:
+   Region: [Global]
+
+- aws_namespace: AWS/CloudFront
+  aws_metric_name: TotalErrorRate
+  aws_statistics: [Average]
+  aws_dimensions: [DistributionId, Region]
+  aws_dimensions_select:
+   Region: [Global]


### PR DESCRIPTION
Add CloudFront exampless

- Region must be set to `us-east-1`
- `aws_dimensions` must be `[DistributionId, Region]`
- `aws_dimensions_select` must be `Region: [Global]`

See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cf-metricscollected.html