### PR TITLE
Add set_timestamp to false to avoid fetching error from Prometheus

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -146,6 +146,7 @@ metrics:
   aws_metric_name: Requests
   aws_statistics: [Sum]
   aws_dimensions: [DistributionId, Region]
+  set_timestamp: false
   aws_dimensions_select:
    Region: [Global]
 
@@ -153,6 +154,7 @@ metrics:
   aws_metric_name: BytesDownloaded
   aws_statistics: [Sum]
   aws_dimensions: [DistributionId, Region]
+  set_timestamp: false
   aws_dimensions_select:
    Region: [Global]
 
@@ -160,6 +162,7 @@ metrics:
   aws_metric_name: 4xxErrorRate
   aws_statistics: [Average]
   aws_dimensions: [DistributionId, Region]
+  set_timestamp: false
   aws_dimensions_select:
    Region: [Global]
 
@@ -167,6 +170,7 @@ metrics:
   aws_metric_name: 5xxErrorRate
   aws_statistics: [Average]
   aws_dimensions: [DistributionId, Region]
+  set_timestamp: false
   aws_dimensions_select:
    Region: [Global]
 
@@ -174,6 +178,7 @@ metrics:
   aws_metric_name: BytesUploaded
   aws_statistics: [Sum]
   aws_dimensions: [DistributionId, Region]
+  set_timestamp: false
   aws_dimensions_select:
    Region: [Global]
 
@@ -181,5 +186,6 @@ metrics:
   aws_metric_name: TotalErrorRate
   aws_statistics: [Average]
   aws_dimensions: [DistributionId, Region]
+  set_timestamp: false
   aws_dimensions_select:
    Region: [Global]


### PR DESCRIPTION
Signed-off-by: Celien Nanson <cesliens@gmail.com>

See: https://github.com/prometheus/cloudwatch_exporter/issues/100

If this is not performed, Prometheus will fail fetching the metric with `msg="Error on ingesting samples that are too old or are too far into the future"`. 
