### PR TITLE
add health/ready endpoints

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -10,6 +10,8 @@ public class HealthServlet extends HttpServlet {
 
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setContentType("text/html");
-        resp.getWriter().print("OK");
+        resp.getWriter().print("<!doctype html><html lang=en>" + 
+            "<head><meta charset=utf-8><title>cloudwatch exporter</title></head>" +
+            "<body>ok</body></html>");
     }
 }

--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -1,0 +1,15 @@
+package io.prometheus.cloudwatch;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HealthServlet extends HttpServlet {
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/html");
+        resp.getWriter().print("OK");
+    }
+}

--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -9,9 +9,7 @@ import java.io.IOException;
 public class HealthServlet extends HttpServlet {
 
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setContentType("text/html");
-        resp.getWriter().print("<!doctype html><html lang=en>" + 
-            "<head><meta charset=utf-8><title>cloudwatch exporter</title></head>" +
-            "<body>ok</body></html>");
+        resp.setContentType("text/plain");
+        resp.getWriter().print("ok");
     }
 }

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -33,6 +33,8 @@ public class WebServer {
         server.setHandler(context);
         context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
         context.addServlet(new ServletHolder(new DynamicReloadServlet(collector)), "/-/reload");
+        context.addServlet(new ServletHolder(new HealthServlet()), "/-/healthy");
+        context.addServlet(new ServletHolder(new HealthServlet()), "/-/ready");
         context.addServlet(new ServletHolder(new HomePageServlet()), "/");
         server.start();
         server.join();


### PR DESCRIPTION
#### Problem

I wanted to have a k8s pod for running my cloud watch exporter, but no readiness/health endpoint exists

#### Solution

Add one. These seem a little bit silly (they both just respond if the server is running, and don't say anything about the status of the connection to AWS (I took inspiration from prometheus: https://github.com/prometheus/prometheus/blob/2bd510a63e48ac6bf4971d62199bdb1045c93f1a/web/web.go#L297-L304) 

This also addresses: https://github.com/prometheus/cloudwatch_exporter/issues/32, which was closed but... @brian-brazil 
