### PR TITLE
Improved Dockerfile: Seperate runtime and buildtime images, use openjdk instead of java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java
+FROM openjdk:10
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 EXPOSE 9106
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:10
+FROM openjdk:10 as builder
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 EXPOSE 9106
 
@@ -7,10 +7,11 @@ ADD . /cloudwatch_exporter
 RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
     mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
     rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
+
+FROM openjdk:10-jre-slim as runner
 WORKDIR /
-
 RUN mkdir /config
-
 ONBUILD ADD config.yml /config/
+COPY --from=builder /cloudwatch_exporter.jar /cloudwatch_exporter.jar
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106"]
 CMD ["/config/config.yml"]


### PR DESCRIPTION
# OpenJDK instead of Java

The "java" image on Docker Hub is deprecated and has not received any updates since 2016-12-31. This PR changes the base image to `openjdk:10` and `openjdk:10-jre-slim` for the runtime image. Java 10 is the latest stable version.

# Seperate runtime image

To make the final Docker image, a [multi step build](https://docs.docker.com/develop/develop-images/multistage-build/) can be used. The project is compiled in the "builder" step, and the jar is copied over to the "runner" build step.

The new image size is 293MB instead of 767MB.
