### PR TITLE
Do not request dimensions when they are stated

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ to do API requests to determine what metrics to request. This should be
 negligible compared to the requests for the metrics themselves.
 
 In the case that all `aws_dimensions` are provided in the `aws_dimension_select` list, the exporter will not perform the
-above api request, which might also reduce the cost.
+above API request.  It will request all possible combination of values for those dimensions.
+This will reduce cost as the values for the dimensions do not need to be queried anymore, assuming that all possible value combinations are present in CloudWatch.
 
 If you have 100 API requests every minute, with the price of USD$10 per million
 requests (as of Aug 2018), that is around $45 per month. The

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ statistics. In addition, when `aws_dimensions` is provided, the exporter needs
 to do API requests to determine what metrics to request. This should be
 negligible compared to the requests for the metrics themselves.
 
-In the case only one `aws_dimensions` is provided together with its `aws_dimension_select` list, the exporter will not
-do the above api request, which might also reduce the cost.
+In the case that all `aws_dimensions` are provided in the `aws_dimension_select` list, the exporter will not perform the
+above api request, which might also reduce the cost.
 
 If you have 100 API requests every minute, with the price of USD$10 per million
 requests (as of Aug 2018), that is around $45 per month. The

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ statistics. In addition, when `aws_dimensions` is provided, the exporter needs
 to do API requests to determine what metrics to request. This should be
 negligible compared to the requests for the metrics themselves.
 
+In the case only one `aws_dimensions` is provided together with its `aws_dimension_select` list, the exporter will not
+do the above api request, which might also reduce the cost.
+
 If you have 100 API requests every minute, with the price of USD$10 per million
 requests (as of Aug 2018), that is around $45 per month. The
 `cloudwatch_requests_total` counter tracks how many requests are being made.


### PR DESCRIPTION
When only one dimension is defined and a `aws_dimension_select` list is provided, the dimensions are known and do not have to be requested anymore.
This can result in substantial cost savings.

In our setup where we work a lot with temporary instances, we have for example 1000 times more metrics in cloudwatch than we have live instances.
By providing the cloudwatch_exporter a list of live instances via the `aws_dimension_select` property in its configuration file, we can keep the cost cloudwatch cost more under control.