### PR TITLE
Bump dockerfile to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:10 as builder
+FROM openjdk:11 as builder
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
@@ -6,7 +6,7 @@ RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
     mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
     rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
 
-FROM openjdk:10-jre-slim as runner
+FROM openjdk:11-jre-slim as runner
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 EXPOSE 9106
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.15</version>
+	  <configuration>
+              <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+	  </configuration>
       </plugin>
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #156. Have built this locally and confirmed it's working with our configuration.

I had to patch `pom.xml` to workaround an upstream Debian bug,

* https://github.com/docker-library/openjdk/issues/247
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925