### PR TITLE
Upgrade jackson-databind to version 2.9.7 due to security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,17 @@
       <artifactId>aws-java-sdk-sts</artifactId>
       <version>1.11.86</version>
     </dependency>
+    <!--
+      Older versions of jackson-databind have remote code execution vulnerabilities
+      CVEs - 2018-5968, 2017-17485, 2017-7525, 2017-15095, 2018-7489
+      This cannot be upgraded directly in aws-java-sdk because it requires
+      jackson-databind 2.6 to support Java 6 customers
+    -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.7</version>
+    </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
Older versions of the jackson-databind library have the following remote code execution vulnerabilities:

- [CVE-2018-5968](https://nvd.nist.gov/vuln/detail/CVE-2018-5968)
- [CVE-2017-17485](https://nvd.nist.gov/vuln/detail/CVE-2017-17485)
- [CVE-2017-7525](https://nvd.nist.gov/vuln/detail/CVE-2017-7525)
- [CVE-2017-15095](https://nvd.nist.gov/vuln/detail/CVE-2017-15095)
- [CVE-2018-7489](https://nvd.nist.gov/vuln/detail/CVE-2018-7489)

These have been fixed in version 2.9.7.

cc @brian-brazil 