### PR TITLE
Update HealthServlet to issue 5xx reponses when there are scrape errors

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -8,8 +8,20 @@ import java.io.IOException;
 
 public class HealthServlet extends HttpServlet {
 
+    private final CloudWatchCollector collector;
+
+    public HealthServlet(CloudWatchCollector collector) {
+        super();
+        this.collector = collector;
+    }
+
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setContentType("text/plain");
-        resp.getWriter().print("ok");
+        if (collector.isScrapeError()) {
+            resp.getWriter().print(CloudWatchCollector.SCRAPE_ERROR_MSG);
+            resp.setStatus(500);
+        } else {
+            resp.getWriter().print("ok");
+        }
     }
 }

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -33,11 +33,10 @@ public class WebServer {
         server.setHandler(context);
         context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
         context.addServlet(new ServletHolder(new DynamicReloadServlet(collector)), "/-/reload");
-        context.addServlet(new ServletHolder(new HealthServlet()), "/-/healthy");
-        context.addServlet(new ServletHolder(new HealthServlet()), "/-/ready");
+        context.addServlet(new ServletHolder(new HealthServlet(collector)), "/-/healthy");
+        context.addServlet(new ServletHolder(new HealthServlet(collector)), "/-/ready");
         context.addServlet(new ServletHolder(new HomePageServlet()), "/");
         server.start();
         server.join();
     }
 }
-


### PR DESCRIPTION
https://github.com/prometheus/cloudwatch_exporter/pull/116 added `/-/ready` and `/-/healthy` endpoints for use in readiness and liveness probes in Kubernetes. When the exporter continuously fails to pull data from CloudWatch, the endpoints should return a non-200 response code in order to signify to Kubernetes that something may be wrong with the container. Kubernetes can then take action if the probes fail repeatedly and restart the container if necessary

@brian-brazil 