### PR TITLE
Update AWS SDK to 1.11.511

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.11.86</version>
+      <version>1.11.511</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.86</version>
+      <version>1.11.511</version>
     </dependency>
     <!--
       Older versions of jackson-databind have remote code execution vulnerabilities


### PR DESCRIPTION
We would like to update the AWS SDK version to the current release 1.11.511 as 1.11.86 brings in httpclient 4.5.2 which has this directory traversal vulnerability: [HTTPCLIENT-1803](https://issues.apache.org/jira/browse/HTTPCLIENT-1803)