### PR TITLE
@brian-brazil Update jetty-servlet to 9.4.15.v20190215

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prom
 
 ## Building and running
 
+Cloudwatch Exporter requires at least Java 8.
+
 `mvn package` to build.
 
 `java -jar target/cloudwatch_exporter-*-SNAPSHOT-jar-with-dependencies.jar 9106 example.yml` to run.

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>8.1.7.v20120910</version>
+        <version>9.4.15.v20190215</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
We would like to update jetty-servlet to 9.4.15.v20190215 in order to address the following CVEs:

* [CVE-2017-7657](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-7657)
* [CVE-2017-7658](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-7658)
* [CVE-2017-7656](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-7656)

Signed-off-by: Fredrick Meunier <fmeunier@tyro.com>