### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 9106
 
 WORKDIR /
 RUN mkdir /config
-ONBUILD ADD config.yml /config/
+ADD example.yml /config/config.yml
 COPY --from=builder /cloudwatch_exporter.jar /cloudwatch_exporter.jar
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106"]
 CMD ["/config/config.yml"]


### PR DESCRIPTION
Replace config.yml file to example.yml and remove ONBUILD instruction.

Getting error to run that image, but docker builds though.

```
Exception in thread "main" java.io.FileNotFoundException: /config/config.yml (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:112)
	at java.base/java.io.FileReader.<init>(FileReader.java:60)
	at io.prometheus.cloudwatch.WebServer.main(WebServer.java:25)
```