### PR TITLE
Switch to Alpine image (bump to Java 13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM openjdk:11 as builder
+FROM openjdk:13-alpine3.9 as builder
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
-    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
-    rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
+RUN apk add maven &&\
+    mvn -q package &&\
+    mvn -q dependency:purge-local-repository && \
+    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar &&\
+    apk del maven
 
-FROM openjdk:11-jre-slim as runner
+FROM openjdk:13-alpine3.9 as runner
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 EXPOSE 9106
 


### PR DESCRIPTION
the previous java 11 image is base on debian and currently has a number of CVE's listed as high vulnerabilities. The change to Alpine (which also requires the bump to java 13) eliminates the vulnerabilities and would allow anyone that requires clair scanning to pass to deploy the image