### PR TITLE
Close the FileReader

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -89,8 +89,13 @@ public class CloudWatchCollector extends Collector {
 
     protected void reloadConfig() throws IOException {
         LOGGER.log(Level.INFO, "Reloading configuration");
-
-        loadConfig(new FileReader(WebServer.configFilePath), activeConfig.client);
+        FileReader reader = null;
+        try {
+          reader = new FileReader(WebServer.configFilePath);
+          loadConfig(reader, activeConfig.client);
+        } finally {
+          reader.close();
+        }
     }
 
     protected void loadConfig(Reader in, AmazonCloudWatchClient client) throws IOException {

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -22,7 +22,16 @@ public class WebServer {
         }
 
         configFilePath = args[1];
-        CloudWatchCollector collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
+
+        CloudWatchCollector collector = null;
+        FileReader reader = null;
+
+        try {
+          reader = new FileReader(configFilePath);
+          collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
+        } finally {
+          reader.close();
+        }
 
         ReloadSignalHandler.start(collector);
 


### PR DESCRIPTION
The purpose of this PR is to close the FileReader after use. If the reloadConfig method is called excessively, it could potentially leak a number of FDs.