### PR TITLE
Improve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:11 as builder
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
+RUN apt-get update -qq && apt-get install -qq maven && mvn --quiet package && \
     mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
 
 FROM openjdk:11-jre-slim as runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:11 as builder
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN apt-get update -qq && apt-get install -qq maven && mvn --quiet package && \
+RUN apt-get update -qq && apt-get install -qq maven && mvn package && \
     mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
 
 FROM openjdk:11-jre-slim as runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM openjdk:11 as builder
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
 RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
-    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
-    rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
+    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
 
 FROM openjdk:11-jre-slim as runner
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>


### PR DESCRIPTION
There are two improvements in this PR:
- Decrease build time: since we are using `builder` intermediate container we can skip cleanup step
- Decrease amount of meaningless messages during build process
