### PR TITLE
Fix metric loading for AWS/ES

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -259,8 +259,16 @@ public class CloudWatchCollector extends Collector {
       request.setNamespace(rule.awsNamespace);
       request.setMetricName(rule.awsMetricName);
       List<DimensionFilter> dimensionFilters = new ArrayList<DimensionFilter>();
-      for (String dimension: rule.awsDimensions) {
-        dimensionFilters.add(new DimensionFilter().withName(dimension));
+      if ("AWS/ES".equals(rule.awsNamespace)) {
+        for (Map.Entry<String, List<String>> dimension : rule.awsDimensionSelect.entrySet()) {
+          dimensionFilters.add(new DimensionFilter()
+            .withName(dimension.getKey())
+            .withValue(dimension.getValue().get(0)));
+          }
+        } else {
+          for (String dimension : rule.awsDimensions) {
+            dimensionFilters.add(new DimensionFilter().withName(dimension));
+          }
       }
       request.setDimensions(dimensionFilters);
 


### PR DESCRIPTION
AWS ElasticSearch does not return any metrics when the client ID and the cluster are not set. This PR takes the `awsDimensionSelect` and puts that into the dimension filters with the values, so the metrics will actually return a value. 

This is slightly brittle, but so is the AWS API apparently

Let me know what you think @brian-brazil