### PR TITLE
Update AWS SDK to 1.11.658

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.11.511</version>
+      <version>1.11.658</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.511</version>
+      <version>1.11.658</version>
     </dependency>
     <!--
       Older versions of jackson-databind have remote code execution vulnerabilities


### PR DESCRIPTION
Using IAM Service roles for EKS needs a newer version of the SDK.
Updating to the latest at the time of writing