### PR TITLE
Only close file if we opened a file.

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -96,7 +96,10 @@ public class CloudWatchCollector extends Collector {
           reader = new FileReader(WebServer.configFilePath);
           loadConfig(reader, activeConfig.client);
         } finally {
-          reader.close();
+          if (reader != null) {
+            reader.close();
+          }
+          
         }
     }
 

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -26,7 +26,9 @@ public class WebServer {
           reader = new FileReader(configFilePath);
           collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
         } finally {
-          reader.close();
+          if (reader != null) {
+            reader.close();
+          }
         }
 
         ReloadSignalHandler.start(collector);


### PR DESCRIPTION
I noticed when testing stuff locally, that if I point it to a file that doesn't exist calling `reader.close();` causes an error (NullPointerException) which hides the original error (FileNotFoundException)
This fixes that situation.