### PR TITLE
Support resources tags as metric label

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ metrics:
    aws_statistics: [Sum]
 ```
 
-A similar example with common options and `aws_tag_select`:
+A similar example with common options, `aws_tag_select` and `enable_aws_resource_info`:
 ```
 ---
 region: eu-west-1
+enable_aws_resource_info : true
 metrics:
  - aws_namespace: AWS/ELB
    aws_metric_name: RequestCount
@@ -68,9 +69,10 @@ aws_dimensions | Optional. Which dimension to fan out over.
 aws_dimension_select | Optional. Which dimension values to filter. Specify a map from the dimension name to a list of values to select from that dimension.
 aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension.
 aws_tag_select | Optional. A tag configuration to filter on, based on mapping from the tagged resource ID to a CloudWatch dimension.  
-tag_selections | Required under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
-resource_type_selection | Required under `aws_tag_select`. Specify the [resource type](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namesspaces) to filter on.
-resource_id_dimension | Required under `aws_tag_select`. For the current metric, specify which CloudWatch dimension maps to the ARN [resource ID](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
+tag_selections | Required, under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
+resource_type_selection | Required, under `aws_tag_select`. Specify the [resource type](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namesspaces) to filter on.
+resource_id_dimension | Required, under `aws_tag_select`. For the current metric, specify which CloudWatch dimension maps to the ARN [resource ID](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
+enable_aws_resource_info | Optional, under `aws_tag_select`. Boolean for whether to enable the export of `aws_resource_info` metric from tagging API results. Defaults to false. Can be set globally and per `aws_tag_select`.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics unless extended statistics are requested.
 aws_extended_statistics | Optional. A list of extended statistics to retrieve. Extended statistics currently include percentiles in the form `pN` or `pN.N`.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
@@ -86,7 +88,7 @@ aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",av
 aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
 ```
 
-If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS resource matched by the tag selection, such as
+If `enable_aws_resource_info` is set to true, an additional information metric will be exported for each AWS resource matched by `aws_tag_select`, such as
 ```
 # HELP aws_resource_info AWS information available for resource
 # TYPE aws_resource_info gauge

--- a/README.md
+++ b/README.md
@@ -82,8 +82,15 @@ The above config will export time series such as
 ```
 # HELP aws_elb_request_count_sum CloudWatch metric AWS/ELB RequestCount Dimensions: ["AvailabilityZone","LoadBalancerName"] Statistic: Sum Unit: Count
 # TYPE aws_elb_request_count_sum gauge
-aws_elb_request_count_sum{job="aws_elb",load_balancer_name="mylb",availability_zone="eu-west-1c",} 42.0
-aws_elb_request_count_sum{job="aws_elb",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
+aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",availability_zone="eu-west-1c",} 42.0
+aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
+```
+
+If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS resource matched by the tag selection, such as
+```
+# HELP aws_resource_info AWS information available for resource
+# TYPE aws_resource_info gauge
+aws_resource_info{job="aws_elb",instance="",load_balancer_name="mylb",tag_Monitoring="enabled",tag_MyOtherKey="MyOtherValue",} 1.0
 ```
 
 All metrics are exported as gauges.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ metrics:
    aws_statistics: [Sum]
 ```
 
-A similar example with common options, `aws_tag_select` and `enable_aws_resource_info`:
+A similar example with common options and `aws_tag_select`:
 ```
 ---
 region: eu-west-1
-enable_aws_resource_info : true
 metrics:
  - aws_namespace: AWS/ELB
    aws_metric_name: RequestCount
@@ -72,7 +71,6 @@ aws_tag_select | Optional. A tag configuration to filter on, based on mapping fr
 tag_selections | Required, under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
 resource_type_selection | Required, under `aws_tag_select`. Specify the [resource type](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namesspaces) to filter on.
 resource_id_dimension | Required, under `aws_tag_select`. For the current metric, specify which CloudWatch dimension maps to the ARN [resource ID](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
-enable_aws_resource_info | Optional, under `aws_tag_select`. Boolean for whether to enable the export of `aws_resource_info` metric from tagging API results. Defaults to false. Can be set globally and per `aws_tag_select`.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics unless extended statistics are requested.
 aws_extended_statistics | Optional. A list of extended statistics to retrieve. Extended statistics currently include percentiles in the form `pN` or `pN.N`.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
@@ -88,7 +86,7 @@ aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",av
 aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
 ```
 
-If `enable_aws_resource_info` is set to true, an additional information metric will be exported for each AWS resource matched by `aws_tag_select`, such as
+If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS resource matched by the tag selection, such as
 ```
 # HELP aws_resource_info AWS information available for resource
 # TYPE aws_resource_info gauge

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If an error occurs during the reload, check the exporter's log output.
 
 ### Cost
 
-Amazon charges for every API request, see the [current charges](http://aws.amazon.com/cloudwatch/pricing/).
+Amazon charges for every CloudWatch API request, see the [current charges](http://aws.amazon.com/cloudwatch/pricing/).
 
 Every metric retrieved requires one API request, which can include multiple
 statistics. In addition, when `aws_dimensions` is provided, the exporter needs
@@ -166,6 +166,9 @@ This will reduce cost as the values for the dimensions do not need to be queried
 If you have 100 API requests every minute, with the price of USD$10 per million
 requests (as of Aug 2018), that is around $45 per month. The
 `cloudwatch_requests_total` counter tracks how many requests are being made.
+
+When using the `aws_tag_select` feature, additional requests are made to the Resource Groups Tagging API, but these are [free](https://aws.amazon.com/blogs/aws/new-aws-resource-tagging-api/).
+The `tagging_api_requests_total` counter tracks how many requests are being made for these.
 
 ## Docker Image
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If the `aws_tag_select` feature was used, an additional information metric will 
 ```
 # HELP aws_resource_info AWS information available for resource
 # TYPE aws_resource_info gauge
-aws_resource_info{job="aws_elb",instance="",load_balancer_name="mylb",tag_Monitoring="enabled",tag_MyOtherKey="MyOtherValue",} 1.0
+aws_resource_info{job="aws_elb",instance="",arn="arn:aws:elasticloadbalancing:eu-west-1:121212121212:loadbalancer/mylb",load_balancer_name="mylb",tag_Monitoring="enabled",tag_MyOtherKey="MyOtherValue",} 1.0
 ```
 
 All metrics are exported as gauges.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ aws_dimensions | Optional. Which dimension to fan out over.
 aws_dimension_select | Optional. Which dimension values to filter. Specify a map from the dimension name to a list of values to select from that dimension.
 aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension.
 aws_tag_select | Optional. A tag configuration to filter on, based on mapping from the tagged resource ID to a CloudWatch dimension.  
-tag_selections | Required, under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
+tag_selections | Optional, under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
 resource_type_selection | Required, under `aws_tag_select`. Specify the [resource type](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namesspaces) to filter on.
 resource_id_dimension | Required, under `aws_tag_select`. For the current metric, specify which CloudWatch dimension maps to the ARN [resource ID](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics unless extended statistics are requested.
@@ -86,7 +86,7 @@ aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",av
 aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
 ```
 
-If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS resource matched by the tag selection, such as
+If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS tagged resource matched by the resource type selection and tag selection (if specified), such as
 ```
 # HELP aws_resource_info AWS information available for resource
 # TYPE aws_resource_info gauge

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -621,7 +621,7 @@ public class CloudWatchCollector extends Collector {
           mfs.add(new MetricFamilySamples(baseName + "_" + safeName(toSnakeCase(entry.getKey())), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
         }
         
-        // Add the "aws_resource_info" metric if tag mappings are available
+        // Add the "aws_resource_info" metric for existing tag mappings
         for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
           if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
             List<String> labelNames = new ArrayList<String>();

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -621,27 +621,25 @@ public class CloudWatchCollector extends Collector {
           mfs.add(new MetricFamilySamples(baseName + "_" + safeName(toSnakeCase(entry.getKey())), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
         }
         
-        // Add the "aws_resource_info" metric if tag configuration was used
-        if (rule.awsTagSelect != null) {
-          for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
-            if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
-              List<String> labelNames = new ArrayList<String>();
-              List<String> labelValues = new ArrayList<String>();
-              labelNames.add("job");
-              labelValues.add(jobName);
-              labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
-              labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
-              for (Tag tag: resourceTagMapping.getTags()) {
-        	// Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
-                labelNames.add("tag_" + safeName(toSnakeCase(tag.getKey())));
-                labelValues.add(tag.getValue());
-              }
-              List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
-              samples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
-              mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", samples));
-              
-              publishedResourceInfo.add(resourceTagMapping.getResourceARN());
+        // Add the "aws_resource_info" metric if tag mappings are available
+        for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
+          if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
+            List<String> labelNames = new ArrayList<String>();
+            List<String> labelValues = new ArrayList<String>();
+            labelNames.add("job");
+            labelValues.add(jobName);
+            labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
+            labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
+            for (Tag tag: resourceTagMapping.getTags()) {
+              // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
+              labelNames.add("tag_" + safeName(toSnakeCase(tag.getKey())));
+              labelValues.add(tag.getValue());
             }
+            List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+            samples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
+            mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", samples));
+            
+            publishedResourceInfo.add(resourceTagMapping.getResourceARN());
           }
         }
       }

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -630,6 +630,8 @@ public class CloudWatchCollector extends Collector {
             labelValues.add(jobName);
             labelNames.add("instance");
             labelValues.add("");
+            labelNames.add("arn");
+            labelValues.add(resourceTagMapping.getResourceARN());
             labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
             labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
             for (Tag tag: resourceTagMapping.getTags()) {

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -232,16 +232,18 @@ public class CloudWatchCollector extends Collector {
 
           if (yamlMetricRule.containsKey("aws_tag_select")) {
             Map<String, Object> yamlAwsTagSelect = (Map<String, Object>) yamlMetricRule.get("aws_tag_select");
-            if (!yamlAwsTagSelect.containsKey("resource_type_selection") || !yamlAwsTagSelect.containsKey("resource_id_dimension") ||
-              !yamlAwsTagSelect.containsKey("tag_selections")) {
-              throw new IllegalArgumentException("Must provide resource_type_selection, resource_id_dimension and tag_selections");
+            if (!yamlAwsTagSelect.containsKey("resource_type_selection") || !yamlAwsTagSelect.containsKey("resource_id_dimension")) {
+              throw new IllegalArgumentException("Must provide resource_type_selection and resource_id_dimension");
             }
             AWSTagSelect awsTagSelect = new AWSTagSelect();
             rule.awsTagSelect = awsTagSelect;
 
             awsTagSelect.resourceTypeSelection = (String)yamlAwsTagSelect.get("resource_type_selection");
             awsTagSelect.resourceIdDimension = (String)yamlAwsTagSelect.get("resource_id_dimension");
-            awsTagSelect.tagSelections = (Map<String, List<String>>)yamlAwsTagSelect.get("tag_selections");
+            
+            if (yamlAwsTagSelect.containsKey("tag_selections")) {
+              awsTagSelect.tagSelections = (Map<String, List<String>>)yamlAwsTagSelect.get("tag_selections");
+            }
           }
         }
 
@@ -283,8 +285,10 @@ public class CloudWatchCollector extends Collector {
       }
 
       List<TagFilter> tagFilters = new ArrayList<TagFilter>();
-      for (Map.Entry<String, List<String>> entry : rule.awsTagSelect.tagSelections.entrySet()) {
-        tagFilters.add(new TagFilter().withKey(entry.getKey()).withValues(entry.getValue()));
+      if (rule.awsTagSelect.tagSelections != null) {
+        for (Map.Entry<String, List<String>> entry : rule.awsTagSelect.tagSelections.entrySet()) {
+          tagFilters.add(new TagFilter().withKey(entry.getKey()).withValues(entry.getValue()));
+        }
       }
 
       List<ResourceTagMapping> resourceTagMappings = new ArrayList<ResourceTagMapping>();

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -87,6 +87,10 @@ public class CloudWatchCollector extends Collector {
             .labelNames("action", "namespace")
             .name("cloudwatch_requests_total").help("API requests made to CloudWatch").register();
 
+    private static final Counter taggingApiRequests = Counter.build()
+        .labelNames("action", "resource_type")
+        .name("tagging_api_requests_total").help("API requests made to the Resource Groups Tagging API").register();
+    
     private static final List<String> brokenDynamoMetrics = Arrays.asList(
             "ConsumedReadCapacityUnits", "ConsumedWriteCapacityUnits",
             "ProvisionedReadCapacityUnits", "ProvisionedWriteCapacityUnits",
@@ -298,6 +302,8 @@ public class CloudWatchCollector extends Collector {
         request.setPaginationToken(paginationToken);
 
         GetResourcesResult result = taggingClient.getResources(request);
+        taggingApiRequests.labels("getResources", rule.awsTagSelect.resourceTypeSelection).inc();
+        
         resourceTagMappings.addAll(result.getResourceTagMappingList());
 
         paginationToken = result.getPaginationToken();

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -79,6 +79,7 @@ public class CloudWatchCollector extends Collector {
       String resourceTypeSelection;
       String resourceIdDimension;
       Map<String,List<String>> tagSelections;
+      boolean enableAwsResourceInfo;
     }
     
     ActiveConfig activeConfig = new ActiveConfig();
@@ -149,6 +150,11 @@ public class CloudWatchCollector extends Collector {
             defaultCloudwatchTimestamp = (Boolean)config.get("set_timestamp");
         }
 
+        boolean defaultEnableAwsResourceInfo = false;
+        if (config.containsKey("enable_aws_resource_info")) {
+          defaultEnableAwsResourceInfo = (Boolean)config.get("enable_aws_resource_info");
+        }
+        
         if (cloudWatchClient == null) {
           AmazonCloudWatchClientBuilder clientBuilder = AmazonCloudWatchClientBuilder.standard();
 
@@ -242,6 +248,12 @@ public class CloudWatchCollector extends Collector {
             awsTagSelect.resourceTypeSelection = (String)yamlAwsTagSelect.get("resource_type_selection");
             awsTagSelect.resourceIdDimension = (String)yamlAwsTagSelect.get("resource_id_dimension");
             awsTagSelect.tagSelections = (Map<String, List<String>>)yamlAwsTagSelect.get("tag_selections");
+            
+            if (yamlAwsTagSelect.containsKey("enable_aws_resource_info")) {
+              awsTagSelect.enableAwsResourceInfo = (Boolean)yamlAwsTagSelect.get("enable_aws_resource_info");
+            } else {
+              awsTagSelect.enableAwsResourceInfo = defaultEnableAwsResourceInfo;
+            }
           }
         }
 
@@ -621,30 +633,32 @@ public class CloudWatchCollector extends Collector {
           mfs.add(new MetricFamilySamples(baseName + "_" + safeName(toSnakeCase(entry.getKey())), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
         }
         
-        // Add the "aws_resource_info" metric for existing tag mappings
-        for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
-          if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
-            List<String> labelNames = new ArrayList<String>();
-            List<String> labelValues = new ArrayList<String>();
-            labelNames.add("job");
-            labelValues.add(jobName);
-            labelNames.add("instance");
-            labelValues.add("");
-            labelNames.add("arn");
-            labelValues.add(resourceTagMapping.getResourceARN());
-            labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
-            labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
-            for (Tag tag: resourceTagMapping.getTags()) {
-              // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
-              // The AWS tags are case sensitive, so to avoid loosing information and label collisions, tag keys are not snaked cased
-              labelNames.add("tag_" + safeName(tag.getKey()));
-              labelValues.add(tag.getValue());
+        if (rule.awsTagSelect != null && rule.awsTagSelect.enableAwsResourceInfo) {
+          // Add the "aws_resource_info" metric for existing tag mappings
+          for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
+            if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
+              List<String> labelNames = new ArrayList<String>();
+              List<String> labelValues = new ArrayList<String>();
+              labelNames.add("job");
+              labelValues.add(jobName);
+              labelNames.add("instance");
+              labelValues.add("");
+              labelNames.add("arn");
+              labelValues.add(resourceTagMapping.getResourceARN());
+              labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
+              labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
+              for (Tag tag: resourceTagMapping.getTags()) {
+                // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
+                // The AWS tags are case sensitive, so to avoid loosing information and label collisions, tag keys are not snaked cased
+                labelNames.add("tag_" + safeName(tag.getKey()));
+                labelValues.add(tag.getValue());
+              }
+              List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+              samples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
+              mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", samples));
+              
+              publishedResourceInfo.add(resourceTagMapping.getResourceARN());
             }
-            List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
-            samples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
-            mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", samples));
-            
-            publishedResourceInfo.add(resourceTagMapping.getResourceARN());
           }
         }
       }

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -628,11 +628,14 @@ public class CloudWatchCollector extends Collector {
             List<String> labelValues = new ArrayList<String>();
             labelNames.add("job");
             labelValues.add(jobName);
+            labelNames.add("instance");
+            labelValues.add("");
             labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
             labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
             for (Tag tag: resourceTagMapping.getTags()) {
               // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
-              labelNames.add("tag_" + safeName(toSnakeCase(tag.getKey())));
+              // The AWS tags are case sensitive, so to avoid loosing information and label collisions, tag keys are not snaked cased
+              labelNames.add("tag_" + safeName(tag.getKey()));
               labelValues.add(tag.getValue());
             }
             List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -475,9 +475,9 @@ public class CloudWatchCollectorTest {
   
   @Test
   public void testTagSelectEC2() throws Exception {
-    // Testing "aws_tag_select" with an EC2, with global "enable_aws_resource_info"
+    // Testing "aws_tag_select" with an EC2
     new CloudWatchCollector(
-        "---\nregion: reg\nenable_aws_resource_info : true\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n", 
+        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n", 
         cloudWatchClient, taggingClient).register(registry);
     
     Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
@@ -508,9 +508,9 @@ public class CloudWatchCollectorTest {
   
   @Test
   public void testTagSelectALB() throws Exception {
-    // Testing "aws_tag_select" with an ALB (which have a fairly complex ARN), with a per tag select "enable_aws_resource_info"
+    // Testing "aws_tag_select" with an ALB, which have a fairly complex ARN 
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ApplicationELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancer\n  aws_tag_select:\n    enable_aws_resource_info: true\n    resource_type_selection: \"elasticloadbalancing:loadbalancer/app\"\n    resource_id_dimension: LoadBalancer\n    tag_selections:\n      Monitoring: [enabled]\n", 
+        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ApplicationELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancer\n  aws_tag_select:\n    resource_type_selection: \"elasticloadbalancing:loadbalancer/app\"\n    resource_id_dimension: LoadBalancer\n    tag_selections:\n      Monitoring: [enabled]\n", 
         cloudWatchClient, taggingClient).register(registry);
     
     Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
@@ -548,9 +548,9 @@ public class CloudWatchCollectorTest {
   
   @Test
   public void testTagSelectUsesPaginationToken() throws Exception {
-    // Testing "aws_tag_select" with an EC2, with global "enable_aws_resource_info"
+    // Testing "aws_tag_select" with an EC2
     new CloudWatchCollector(
-        "---\nregion: reg\nenable_aws_resource_info : true\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n", 
+        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n", 
         cloudWatchClient, taggingClient).register(registry);
 
     Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
@@ -615,7 +615,6 @@ public class CloudWatchCollectorTest {
   @Test
   public void testMultipleSelection() throws Exception {
     // When multiple selections are made, "and" logic should be applied on metrics
-    // Having no "enable_aws_resource_info" should default to false
     new CloudWatchCollector(
         "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n  aws_dimension_select:\n    InstanceId: [\"i-1\"]", 
         cloudWatchClient, taggingClient).register(registry);
@@ -644,8 +643,8 @@ public class CloudWatchCollectorTest {
 
     assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
     assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
-    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}));
-    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}));
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}), .01);
   }
   
 }

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -503,6 +503,9 @@ public class CloudWatchCollectorTest {
 
     assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
     assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
+    
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-1", "enabled"}), .01);
+    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-2", "enabled"}));
   }
   
   @Test
@@ -542,6 +545,9 @@ public class CloudWatchCollectorTest {
     assertEquals(2.0, registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "a", "app/myLB/123"}), .01);
     assertEquals(3.0, registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "b", "app/myLB/123"}), .01);
     assertNull(registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "a", "app/myOtherLB/456"}));
+
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "load_balancer", "tag_Monitoring"}, new String[]{"aws_applicationelb", "", "app/myLB/123", "enabled"}), .01);
+    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "load_balancer", "tag_Monitoring"}, new String[]{"aws_applicationelb", "", "app/myOtherLB/456", "enabled"}));
   }
   
   @Test
@@ -579,6 +585,9 @@ public class CloudWatchCollectorTest {
 
     assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
     assertEquals(3.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}), .01);
+    
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-1", "enabled"}), .01);
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-2", "enabled"}), .01);
   }
   
   @Test

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -503,9 +503,7 @@ public class CloudWatchCollectorTest {
 
     assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
     assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
-    
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-1", "enabled"}), .01);
-    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-2", "enabled"}));
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
   }
   
   @Test
@@ -545,9 +543,7 @@ public class CloudWatchCollectorTest {
     assertEquals(2.0, registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "a", "app/myLB/123"}), .01);
     assertEquals(3.0, registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "b", "app/myLB/123"}), .01);
     assertNull(registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "a", "app/myOtherLB/456"}));
-
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "load_balancer", "tag_Monitoring"}, new String[]{"aws_applicationelb", "", "app/myLB/123", "enabled"}), .01);
-    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "load_balancer", "tag_Monitoring"}, new String[]{"aws_applicationelb", "", "app/myOtherLB/456", "enabled"}));
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "load_balancer", "tag_Monitoring"}, new String[]{"aws_applicationelb", "", "arn:aws:elasticloadbalancing:us-east-1:121212121212:loadbalancer/app/myLB/123", "app/myLB/123", "enabled"}), .01);
   }
   
   @Test
@@ -585,9 +581,8 @@ public class CloudWatchCollectorTest {
 
     assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
     assertEquals(3.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}), .01);
-    
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-1", "enabled"}), .01);
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "i-2", "enabled"}), .01);
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
+    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}), .01);
   }
   
   @Test


### PR DESCRIPTION
Hi @brian-brazil,

As discussed with you in the latest #96 issue comments (item 2. : "if we happen to have the metadata for it"), this PR adds the resources tags as metric label in a new metric called `aws_resource_info`. This metric contains tags as labels for resources selected through `aws_tag_select`, and can later be joined to other metrics through PromQL queries.

Note that I have kept the empty `instance` label, even though I am not sure of the reason it is there, both in the case of the new metric and in other existing metrics. I'm curious to have your comment on that.

Thanks!