### PR TITLE
Enhance unit test for resource with not tag when tag_selection is not specified

### DIFF
--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -649,9 +649,9 @@ public class CloudWatchCollectorTest {
   
   @Test
   public void testOptionalTagSelection() throws Exception {
-    // aws_tag_select can be used without tag_selection to activate the aws_resource_info metric
+    // aws_tag_select can be used without tag_selection to activate the aws_resource_info metric on tagged (or previously tagged) resources
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n  aws_dimension_select:\n    InstanceId: [\"i-1\"]", 
+        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n  aws_dimension_select:\n    InstanceId: [\"i-1\", \"i-no-tag\"]", 
         cloudWatchClient, taggingClient).register(registry);
     
     Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
@@ -664,7 +664,8 @@ public class CloudWatchCollectorTest {
         new ListMetricsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimensions("InstanceId"))))
         .thenReturn(new ListMetricsResult().withMetrics(
             new Metric().withDimensions(new Dimension().withName("InstanceId").withValue("i-1")),
-            new Metric().withDimensions(new Dimension().withName("InstanceId").withValue("i-2"))));
+            new Metric().withDimensions(new Dimension().withName("InstanceId").withValue("i-2")),
+            new Metric().withDimensions(new Dimension().withName("InstanceId").withValue("i-no-tag"))));
 
     Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
         new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-1"))))
@@ -675,10 +676,17 @@ public class CloudWatchCollectorTest {
         new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-2"))))
         .thenReturn(new GetMetricStatisticsResult().withDatapoints(
             new Datapoint().withTimestamp(new Date()).withAverage(3.0)));
+    
+    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
+        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-no-tag"))))
+        .thenReturn(new GetMetricStatisticsResult().withDatapoints(
+            new Datapoint().withTimestamp(new Date()).withAverage(4.0)));
 
     assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
     assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
+    assertEquals(4.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-no-tag"}), .01);
     assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
     assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}), .01);
+    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-no-tag", "i-no-tag", "enabled"}));
   }
 }


### PR DESCRIPTION
Hi @brian-brazil ,
As discussed in PR #233 , I'm adding here an enhancement to the unit test to cover the case of a resource with not tag when `tag_selection` is not specified under `aws_tag_select`.
The enhanced test fail without PR #233 , but succeed with it, as expected.
Thanks!