### PR TITLE
Support default provider chain for region

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ metrics:
 
 Name     | Description
 ---------|------------
-region   | Optional. The AWS region to connect to. If none is provided, the region from the instance metadata is used.
+region   | Optional. The AWS region to connect to. If none is provided, an attempt will be made to determine the region from the [default region provider chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html#default-region-provider-chain).
 role_arn   | Optional. The AWS role to assume. Useful for retrieving cross account metrics.
 metrics  | Required. A list of CloudWatch metrics to retrieve and export
 aws_namespace  | Required. Namespace of the CloudWatch metric.

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.argThat;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.model.Datapoint;
 import com.amazonaws.services.cloudwatch.model.Dimension;
@@ -407,17 +405,6 @@ public class CloudWatchCollectorTest {
             new Datapoint().withTimestamp(new Date()).withAverage(2.0)));
 
     assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
-  }
-
-  @Test
-  public void testGetMonitoringEndpoint() throws Exception {
-    Region usEast = RegionUtils.getRegion("us-east-1");
-    CloudWatchCollector us_collector = new CloudWatchCollector("---\nregion: us-east-1\nmetrics: []\n");
-    assertEquals("https://monitoring.us-east-1.amazonaws.com", us_collector.getMonitoringEndpoint(usEast));
-
-    Region cnNorth = RegionUtils.getRegion("cn-north-1");
-    CloudWatchCollector cn_collector = new CloudWatchCollector("---\nregion: cn-north-1\nmetrics: []\n");
-    assertEquals("https://monitoring.cn-north-1.amazonaws.com.cn", cn_collector.getMonitoringEndpoint(cnNorth));
   }
 
   @Test


### PR DESCRIPTION
Adds support for falling back to the default region provider chain to fetch the region if omitted from the configuration file.