### PR TITLE
[Issue-241] Remove ':' from safeName regex pattern

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -494,7 +494,7 @@ public class CloudWatchCollector extends Collector {
 
     private String safeName(String s) {
       // Change invalid chars to underscore, and merge underscores.
-      return s.replaceAll("[^a-zA-Z0-9:_]", "_").replaceAll("__+", "_");
+      return s.replaceAll("[^a-zA-Z0-9_]", "_").replaceAll("__+", "_");
     }
 
     private String help(MetricRule rule, String unit, String statistic) {


### PR DESCRIPTION
Currently, the metrics label name can contain ":" from the exporter, This doesn't match prometheus regex (See [official doc]( https://prometheus.io/docs/concepts/data_model/)), the regex should be `[a-zA-Z0-9_]` In this PR, we change the regex in the safeName function which change the invalid chars to underscore.