### PR TITLE
Update AWS SDK to 1.11.708

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,17 +46,17 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.11.658</version>
+      <version>1.11.708</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.658</version>
+      <version>1.11.708</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-resourcegroupstaggingapi</artifactId>
-      <version>1.11.658</version>
+      <version>1.11.708</version>
     </dependency>
     <!--
       Older versions of jackson-databind have remote code execution vulnerabilities


### PR DESCRIPTION
Version 1.11.704 includes a bugfix for IAM Roles for Service Accounts (IRSA):

https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111704-2020-01-09

This adjusts the priority of the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable so it is accessed before instance metadata. This is required to use IRSA, as mentioned here: https://github.com/prometheus/cloudwatch_exporter/pull/224#issuecomment-572397938