### PR TITLE
correct config.yml steps for building own image

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Specify the config as the CMD:
 $ docker run -p 9106 -v /path/on/host/us-west-1.yml:/config/us-west-1.yml prom/cloudwatch-exporter /config/us-west-1.yml
 ```
 
-Or create a config file named /config/config.yml along with following
+Or create a config file named `config.yml` along with following
 Dockerfile in the same directory and build it with `docker build`:
 
 ```


### PR DESCRIPTION
The ONBUILD command expects `config.yml` to be in the same directory as the `Dockerfile`, not nested in a config directory. The readme was unclear on this point, causing me around five minutes of confusion until I read the parent `Dockerfile`. (This is a separate fix from #204.)