### PR TITLE
Remove onbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ EXPOSE 9106
 
 WORKDIR /
 RUN mkdir /config
-ONBUILD ADD config.yml /config/
 COPY --from=builder /cloudwatch_exporter.jar /cloudwatch_exporter.jar
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106"]
 CMD ["/config/config.yml"]

--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Dockerfile in the same directory and build it with `docker build`:
 
 ```
 FROM prom/cloudwatch-exporter
+ADD config.yml /config/
 ```


### PR DESCRIPTION
The ONBUILD statement in the Dockerfile makes a assumptions about why the image may be built which are very specific and creates unecessary  future dependencies.  It's not really what the 'ONBUILD' command [was introduced for](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). Removing it better aligns with the Docker Principle of build once, use anywhere and not having dependencies on the OS.

The intended capability of adding a `config.yml` file into the image can still easily be achieved.

https://github.com/prometheus/cloudwatch_exporter/issues/72 seems to be saying the same thing