### PR TITLE
Fix/irsa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,17 +46,17 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.11.708</version>
+      <version>1.11.751</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.708</version>
+      <version>1.11.751</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-resourcegroupstaggingapi</artifactId>
-      <version>1.11.708</version>
+      <version>1.11.751</version>
     </dependency>
     <!--
       Older versions of jackson-databind have remote code execution vulnerabilities

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -2,6 +2,7 @@ package io.prometheus.cloudwatch;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.cloudwatch.model.Datapoint;
@@ -159,7 +160,8 @@ public class CloudWatchCollector extends Collector implements Describable {
         String region = (String) config.get("region");
 
         if (cloudWatchClient == null) {
-          AmazonCloudWatchClientBuilder clientBuilder = AmazonCloudWatchClientBuilder.standard();
+          AmazonCloudWatchClientBuilder clientBuilder = AmazonCloudWatchClientBuilder.standard()
+            .withCredentials(WebIdentityTokenCredentialsProvider.create());
 
           if (config.containsKey("role_arn")) {
             clientBuilder.setCredentials(getRoleCredentialProvider(config));
@@ -173,7 +175,8 @@ public class CloudWatchCollector extends Collector implements Describable {
         }
 
         if (taggingClient == null) {
-          AWSResourceGroupsTaggingAPIClientBuilder clientBuilder = AWSResourceGroupsTaggingAPIClientBuilder.standard();
+          AWSResourceGroupsTaggingAPIClientBuilder clientBuilder = AWSResourceGroupsTaggingAPIClientBuilder.standard()
+            .withCredentials(WebIdentityTokenCredentialsProvider.create());
 
           if (config.containsKey("role_arn")) {
             clientBuilder.setCredentials(getRoleCredentialProvider(config));

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -160,11 +160,13 @@ public class CloudWatchCollector extends Collector implements Describable {
         String region = (String) config.get("region");
 
         if (cloudWatchClient == null) {
-          AmazonCloudWatchClientBuilder clientBuilder = AmazonCloudWatchClientBuilder.standard()
-            .withCredentials(WebIdentityTokenCredentialsProvider.create());
+          AmazonCloudWatchClientBuilder clientBuilder = AmazonCloudWatchClientBuilder.standard();
 
           if (config.containsKey("role_arn")) {
             clientBuilder.setCredentials(getRoleCredentialProvider(config));
+          }
+          else if (config.containsKey("aws_use_irsa")) {
+            clientBuilder.setCredentials(WebIdentityTokenCredentialsProvider.create());
           }
 
           if (region != null) {
@@ -175,11 +177,13 @@ public class CloudWatchCollector extends Collector implements Describable {
         }
 
         if (taggingClient == null) {
-          AWSResourceGroupsTaggingAPIClientBuilder clientBuilder = AWSResourceGroupsTaggingAPIClientBuilder.standard()
-            .withCredentials(WebIdentityTokenCredentialsProvider.create());
+          AWSResourceGroupsTaggingAPIClientBuilder clientBuilder = AWSResourceGroupsTaggingAPIClientBuilder.standard();
 
           if (config.containsKey("role_arn")) {
             clientBuilder.setCredentials(getRoleCredentialProvider(config));
+          }
+          else if (config.containsKey("aws_use_irsa")) {
+            clientBuilder.setCredentials(WebIdentityTokenCredentialsProvider.create());
           }
           if (region != null) {
             clientBuilder.setRegion(region);


### PR DESCRIPTION
I wasn't able to get this service to work on EKS with IRSA when the nodes have their own instance profiles (empty policy). The web identity credentials come last in the list and the instance profile was being used ahead of the token file and role passed into containers. The default credential chain for the v1 SDK is listed here: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html

This PR allows a config option of `aws_use_irsa` that will force the use of the WebIdentityTokenCredentialsProvider. The AWS SDK version was also bumped up.