### PR TITLE
allow maven-compiler-plugin to compile without a JDK downgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <!-- Build a full jar with dependencies -->


### PR DESCRIPTION
**Before:**
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
[INFO] 2 errors
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
**After:**
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

Alternatively, one could also remove this so that the default takes over: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html