### PR TITLE
Use `RecentlyActive` feature to only list metrics older than 3 hours when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ delay_seconds | Optional. The newest data to request. Used to avoid collecting d
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
 set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
-recently_active_only | Optional. Boolean for whether to only get metrics that have been updated in the past 3 hours. This is useful for keeping the scrape time down when the dimensions of your metrics change frequently. Defaults to false. Can be set globally or per metric.
 
 The above config will export time series such as
 ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ delay_seconds | Optional. The newest data to request. Used to avoid collecting d
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
 set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
+recently_active_only | Optional. Boolean for whether to only get metrics that have been updated in the past 3 hours. This is useful for keeping the scrape time down when the dimensions of your metrics change frequently. Defaults to false. Can be set globally or per metric.
 
 The above config will export time series such as
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -46,17 +46,17 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudwatch</artifactId>
-      <version>1.11.708</version>
+      <version>1.11.839</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.708</version>
+      <version>1.11.839</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-resourcegroupstaggingapi</artifactId>
-      <version>1.11.708</version>
+      <version>1.11.839</version>
     </dependency>
     <!--
       Older versions of jackson-databind have remote code execution vulnerabilities

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -70,6 +70,7 @@ public class CloudWatchCollector extends Collector implements Describable {
       AWSTagSelect awsTagSelect;
       String help;
       boolean cloudwatchTimestamp;
+      boolean recentlyActiveOnly;
     }
 
     static class AWSTagSelect {
@@ -153,6 +154,11 @@ public class CloudWatchCollector extends Collector implements Describable {
         boolean defaultCloudwatchTimestamp = true;
         if (config.containsKey("set_timestamp")) {
             defaultCloudwatchTimestamp = (Boolean)config.get("set_timestamp");
+        }
+
+        boolean defaultRecentlyActiveOnly = false;
+        if (config.containsKey("recently_active_only")) {
+            defaultRecentlyActiveOnly = (Boolean)config.get("recently_active_only");
         }
         
 
@@ -241,6 +247,11 @@ public class CloudWatchCollector extends Collector implements Describable {
               rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("set_timestamp");
           } else {
               rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
+          }
+          if (yamlMetricRule.containsKey("recently_active_only")) {
+              rule.recentlyActiveOnly = (Boolean)yamlMetricRule.get("recently_active_only");
+          } else {
+              rule.recentlyActiveOnly = defaultRecentlyActiveOnly;
           }
 
           if (yamlMetricRule.containsKey("aws_tag_select")) {
@@ -374,6 +385,11 @@ public class CloudWatchCollector extends Collector implements Describable {
       ListMetricsRequest request = new ListMetricsRequest();
       request.setNamespace(rule.awsNamespace);
       request.setMetricName(rule.awsMetricName);
+
+      if (rule.recentlyActiveOnly) {
+        request.setRecentlyActive("PT3H");
+      }
+
       List<DimensionFilter> dimensionFilters = new ArrayList<DimensionFilter>();
       for (String dimension: rule.awsDimensions) {
         dimensionFilters.add(new DimensionFilter().withName(dimension));

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -70,7 +70,6 @@ public class CloudWatchCollector extends Collector implements Describable {
       AWSTagSelect awsTagSelect;
       String help;
       boolean cloudwatchTimestamp;
-      boolean recentlyActiveOnly;
     }
 
     static class AWSTagSelect {
@@ -155,12 +154,6 @@ public class CloudWatchCollector extends Collector implements Describable {
         if (config.containsKey("set_timestamp")) {
             defaultCloudwatchTimestamp = (Boolean)config.get("set_timestamp");
         }
-
-        boolean defaultRecentlyActiveOnly = false;
-        if (config.containsKey("recently_active_only")) {
-            defaultRecentlyActiveOnly = (Boolean)config.get("recently_active_only");
-        }
-        
 
         String region = (String) config.get("region");
 
@@ -247,11 +240,6 @@ public class CloudWatchCollector extends Collector implements Describable {
               rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("set_timestamp");
           } else {
               rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
-          }
-          if (yamlMetricRule.containsKey("recently_active_only")) {
-              rule.recentlyActiveOnly = (Boolean)yamlMetricRule.get("recently_active_only");
-          } else {
-              rule.recentlyActiveOnly = defaultRecentlyActiveOnly;
           }
 
           if (yamlMetricRule.containsKey("aws_tag_select")) {
@@ -386,7 +374,8 @@ public class CloudWatchCollector extends Collector implements Describable {
       request.setNamespace(rule.awsNamespace);
       request.setMetricName(rule.awsMetricName);
 
-      if (rule.recentlyActiveOnly) {
+      // 10800 seconds is 3 hours, this setting causes metrics older than 3 hours to not be listed
+      if (rule.rangeSeconds < 10800) {
         request.setRecentlyActive("PT3H");
       }
 

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -698,12 +698,12 @@ public class CloudWatchCollectorTest {
   }
 
   @Test
-  public void testRecentlyActiveOnly() throws Exception {
+  public void testNotRecentlyActive() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  recently_active_only: true", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  range_seconds: 12000", cloudWatchClient, taggingClient).register(registry);
 
     Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-            new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName").RecentlyActive("PT3H"))))
+            new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName").RecentlyActive(null))))
             .thenReturn(new ListMetricsResult().withMetrics(
                     new Metric().withDimensions(new Dimension().withName("AvailabilityZone").withValue("a"), new Dimension().withName("LoadBalancerName").withValue("myLB")),
                     new Metric().withDimensions(new Dimension().withName("AvailabilityZone").withValue("a"), new Dimension().withName("LoadBalancerName").withValue("myLB"), new Dimension().withName("ThisExtraDimensionIsIgnored").withValue("dummy")),
@@ -723,7 +723,7 @@ public class CloudWatchCollectorTest {
 
     Mockito.verify(cloudWatchClient).listMetrics((ListMetricsRequest) argThat(
             new ListMetricsRequestMatcher()
-                    .RecentlyActive("PT3H").
+                    .RecentlyActive(null).
                     Namespace("AWS/ELB").
                     MetricName("RequestCount").
                     Dimensions("AvailabilityZone", "LoadBalancerName")


### PR DESCRIPTION
I have the problem that a lot of the dimensions on my CloudWatch metrics change frequently. Because the default behaviour of `listMetrics()` is to return every metric that matches your query and has been updated in the last 2 weeks, this causes the scrape time to be very high. With this option, we can limit the returned metrics to only those which have been updated in the last 3 hours. I also had to update the AWS SDK to allow this, as the version currently being used doesn't have this feature

cc @brian-brazil 