### PR TITLE
Bump snakeyaml to 1.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.17</version>
+      <version>1.27</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>


### PR DESCRIPTION
A vulnerability scan of the `prom/cloudwatch-exporter` image finds this.

|      CVE       | SEVERITY | CVSS |      PACKAGE       |     VERSION      |    STATUS     |  PUBLISHED  | DISCOVERED |                    DESCRIPTION                     |
|----------------|----------|------|--------------------|------------------|---------------|-------------|------------|----------------------------------------------------|
| CVE-2017-18640 | high     | 7.50 | org.yaml_snakeyaml | 1.17             | fixed in 1.26 | > 10 months | < 1 hour   | The Alias feature in SnakeYAML 1.18 allows entity expansion during a load operation, a related issue to CVE-2003-1564.|

The [CVE](https://nvd.nist.gov/vuln/detail/CVE-2017-18640) description implies that it was introduced in `1.18` so it might be a false positive.