### PR TITLE
Pull latest openjdk:11 base image when building the Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           command: docker run --privileged linuxkit/binfmt:v0.7
       - run: |
-          docker build -t quay.io/prometheus/cloudwatch-exporter:latest .
+          docker build -t quay.io/prometheus/cloudwatch-exporter:latest --pull .
           if [[ -n "$CIRCLE_TAG" ]]; then
             docker tag -t quay.io/prometheus/cloudwatch-exporter:"${CIRCLE_TAG}" quay.io/prometheus/cloudwatch-exporter:latest
           fi


### PR DESCRIPTION
This ensures that when a new Docker image is released it will be based on the latest available OpenJDK 11 image.

The currently released `0.9.0` Docker image is based on OpenJDK 11.0.8 which has some known vulnerabilities.

As the Dockerfile specifies a non-specific base image tag the image will be built with whatever version of OpenJDK 11 happens to be cached locally. With this change it will force the latest image pointed to by the tag `11-jre-slim` to be used as the base image, currently `11.0.9.1-jre-slim` (`sha256:28b59dc9a129c75349418e3b75508fd8eef3b33dd7d796079d1d19445d907776`).

The alternative to this would be to use a more specific tag for the base image, so `11.0.9-jre-slim` maybe.


