### PR TITLE
Bump jackson-databind to 2.10.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.0.pr1</version>
+      <version>2.10.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>


### PR DESCRIPTION
Fixes [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649).