### PR TITLE
Bump jetty-servlet to 9.4.15.v20190215

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>9.4.15.v20190215</version>
+        <version>9.4.35.v20201120</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fixes [CVE-2020-27216](https://nvd.nist.gov/vuln/detail/CVE-2020-27216)