### PR TITLE
Change maintainer from @brian-brazil to @matthiasr

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,1 @@
-* Brian Brazil <brian.brazil@robustperception.io>
+* Matthias Rampke <mr@soundcloud.com> @matthiasr


### PR DESCRIPTION
Yesterday at the dev-summit, the Prometheus team has proposed @matthiasr as the new maintainer for this repo after @brian-brazil's retirement from the project. We are also still looking for a co-maintainer who has worked with this exporter more closely than @matthiasr.

This change will only be merged after an announcement on the prometheus-developers mailing list and is subject to lazy consensus.

Thank you, @brian-brazil, for the incredible amount of work done in this repository and for the project in general.
