### PR TITLE
Update example.yml with correct ELB values

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,30 +1,30 @@
 ---
 region: eu-west-1
 metrics:
-- aws_namespace: AWS/ELB
+- aws_namespace: AWS/NetworkELB
   aws_metric_name: HealthyHostCount
-  aws_dimensions: [AvailabilityZone, LoadBalancerName]
+  aws_dimensions: [AvailabilityZone, LoadBalancer, TargetGroup]
   aws_statistics: [Average]
 
-- aws_namespace: AWS/ELB
+- aws_namespace: AWS/NetworkELB
   aws_metric_name: UnHealthyHostCount
-  aws_dimensions: [AvailabilityZone, LoadBalancerName]
+  aws_dimensions: [AvailabilityZone, LoadBalancer, TargetGroup]
   aws_statistics: [Average]
 
-- aws_namespace: AWS/ELB
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: HealthyHostCount
+  aws_dimensions: [AvailabilityZone, LoadBalancer, TargetGroup]
+  aws_statistics: [Average]
+
+- aws_namespace: AWS/ApplicationELB
+  aws_metric_name: UnHealthyHostCount
+  aws_dimensions: [AvailabilityZone, LoadBalancer, TargetGroup]
+  aws_statistics: [Average]
+
+- aws_namespace: AWS/ApplicationELB
   aws_metric_name: RequestCount
-  aws_dimensions: [AvailabilityZone, LoadBalancerName]
-  aws_statistics: [Sum]
-
-- aws_namespace: AWS/ELB
-  aws_metric_name: Latency
-  aws_dimensions: [AvailabilityZone, LoadBalancerName]
+  aws_dimensions: [AvailabilityZone, LoadBalancer]
   aws_statistics: [Average]
-
-- aws_namespace: AWS/ELB
-  aws_metric_name: SurgeQueueLength
-  aws_dimensions: [AvailabilityZone, LoadBalancerName]
-  aws_statistics: [Maximum, Sum]
 
 - aws_namespace: AWS/ElastiCache
   aws_metric_name: CPUUtilization


### PR DESCRIPTION
This PR contains the following changes
- Set the correct ELB values for `aws_namespace` and `aws_dimensions`. The current values will result in metrics not being populated. 
- Remove unavailable metrics `SurgeQueueLength` and `Latency`

To get the correct namespace and dimensions values, run the commands
-  ```aws cloudwatch list-metrics --namespace AWS/ApplicationELB```
-  ```aws cloudwatch list-metrics --namespace AWS/NetworkELB```