### PR TITLE
Add the possibility to add custom labels to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ metrics:
    aws_dimension_select:
      LoadBalancerName: [myLB]
    aws_statistics: [Sum]
+   additional_labels: 
+     lb_type: public
 ```
 
 A similar example with common options and `aws_tag_select`:
@@ -77,13 +79,14 @@ delay_seconds | Optional. The newest data to request. Used to avoid collecting d
 range_seconds | Optional. How far back to request data for. Useful for cases such as Billing metrics that are only set every few hours. Defaults to 600s. Can be set globally and per metric.
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
 set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
+additional_labels | Optional. Map of additional labels to be set on the metric. Can be used to distinguish identical `aws_metric_name` with different `range_seconds` for example. Can only be set per metric.
 
 The above config will export time series such as
 ```
 # HELP aws_elb_request_count_sum CloudWatch metric AWS/ELB RequestCount Dimensions: ["AvailabilityZone","LoadBalancerName"] Statistic: Sum Unit: Count
 # TYPE aws_elb_request_count_sum gauge
-aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",availability_zone="eu-west-1c",} 42.0
-aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
+aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",availability_zone="eu-west-1c",lb_type="public",} 42.0
+aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",lb_type="public",} 7.0
 ```
 
 If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS tagged resource matched by the resource type selection and tag selection (if specified), such as

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -70,6 +70,7 @@ public class CloudWatchCollector extends Collector implements Describable {
       int periodSeconds;
       int rangeSeconds;
       int delaySeconds;
+      Map<String,String> additionalLabels;
       List<Statistic> awsStatistics;
       List<String> awsExtendedStatistics;
       List<String> awsDimensions;
@@ -246,9 +247,14 @@ public class CloudWatchCollector extends Collector implements Describable {
             rule.delaySeconds = defaultDelay;
           }
           if (yamlMetricRule.containsKey("set_timestamp")) {
-              rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("set_timestamp");
+            rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("set_timestamp");
           } else {
-              rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
+            rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
+          }
+          if (yamlMetricRule.containsKey("additional_labels")) {
+            rule.additionalLabels = (Map<String, String>)yamlMetricRule.get("additional_labels");
+          } else {
+            rule.additionalLabels = Collections.emptyMap();
           }
 
           if (yamlMetricRule.containsKey("aws_tag_select")) {
@@ -592,6 +598,11 @@ public class CloudWatchCollector extends Collector implements Describable {
           for (Dimension d: dimensions) {
             labelNames.add(safeLabelName(toSnakeCase(d.name())));
             labelValues.add(d.value());
+          }
+
+          for (Map.Entry<String, String> additionalLabels : rule.additionalLabels.entrySet()) {
+            labelNames.add(safeLabelName(additionalLabels.getKey()));
+            labelValues.add(additionalLabels.getValue());
           }
 
           Long timestamp = null;

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -23,7 +23,7 @@ public class WebServer {
         try (
           FileReader reader = new FileReader(configFilePath);
         ) {
-          collector = new CloudWatchCollector(new FileReader(configFilePath)).register();
+          collector = new CloudWatchCollector(reader).register();
         }
 
         ReloadSignalHandler.start(collector);


### PR DESCRIPTION
My use case is to have multiple metrics with the same `aws_metric_name` but different `period_seconds` and/or `range_seconds`. Example : 
```
metrics:
    - aws_dimension_select_regex:
        DBInstanceIdentifier:
        - some-identifier*
      aws_dimensions:
      - DBInstanceIdentifier
      aws_metric_name: CPUUtilization
      aws_namespace: AWS/RDS
      aws_statistics:
      - Average
      delay_seconds: 90
    - aws_dimension_select_regex:
        DBInstanceIdentifier:
        - some-identifier*
      aws_dimensions:
      - DBInstanceIdentifier
      aws_metric_name: CPUUtilization
      aws_namespace: AWS/RDS
      aws_statistics:
      - Average
      delay_seconds: 90
      period_seconds: 604800
      range_seconds: 604800
```
With the current setup, this will produce 2 metrics with the exact same labels but different values : 
```
# HELP aws_rds_cpuutilization_average CloudWatch metric AWS/RDS CPUUtilization Dimensions: [DBInstanceIdentifier] Statistic: Average Unit: Percent
# TYPE aws_rds_cpuutilization_average gauge
aws_rds_cpuutilization_average{job="aws_rds",instance="",dbinstance_identifier="someidentifier-1",} 9.508491808196803 1634693160000
# HELP aws_rds_cpuutilization_average CloudWatch metric AWS/RDS CPUUtilization Dimensions: [DBInstanceIdentifier] Statistic: Average Unit: Percent
# TYPE aws_rds_cpuutilization_average gauge
aws_rds_cpuutilization_average{job="aws_rds",instance="",dbinstance_identifier="someidentifier-1",} 9.092518065733273 1634088420000
```
Which is useless in prometheus. With this PR, we'll be able to distinguish between the two using labels that you set in the config. I thought about just setting the `delay_seconds`, `period_seconds` and `range_seconds` as default labels however I thought that having specific custom labels (something like `period="weekly"` in this case) is clearer. I'm open to changing my PR for this if you prefer though, it's a matter of preference I believe in the end.

Thanks!