### PR TITLE
circleci: Pass BUILDX_PLATFORMs when building multi-arch images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,17 @@ jobs:
             # Run binfmt
             docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
       - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
-      - run: "if [[ -n \"$CIRCLE_TAG\" ]]; then\n  docker buildx build -t quay.io/prometheus/cloudwatch-exporter:\"${CIRCLE_TAG}\" -t quay.io/prometheus/cloudwatch-exporter:latest --push .          \nelse\n  docker buildx build -t quay.io/prometheus/cloudwatch-exporter:latest --push .          \nfi\n"
+      - run: |
+          if [[ -n "$CIRCLE_TAG" ]]; then
+            docker buildx build \
+              --platform "$BUILDX_PLATFORMS" \
+              -t quay.io/prometheus/cloudwatch-exporter:"${CIRCLE_TAG}" \
+              -t quay.io/prometheus/cloudwatch-exporter:latest --push .
+          else
+            docker buildx build \
+              --platform "$BUILDX_PLATFORMS" \
+              -t quay.io/prometheus/cloudwatch-exporter:latest --push .
+          fi
       - run: docker images
 workflows:
   version: 2


### PR DESCRIPTION
Related to #363. Fixes #337.