### PR TITLE
circleci: Create a buildx builder instance for multiarch build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ jobs:
             docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
       - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
       - run: |
-          docker buildx create --use
+          docker context create ctx
+          docker buildx create ctx --name builder --use
           if [[ -n "$CIRCLE_TAG" ]]; then
             docker buildx build \
               --platform "$BUILDX_PLATFORMS" \


### PR DESCRIPTION
Sorry for breaking the build in my previous PR. 

I used Github container registry for testing as I don't have quay.io account. And this patch seems to work. https://app.circleci.com/pipelines/github/lht/cloudwatch_exporter/7/workflows/fd3230c3-b2e3-4a8b-be0a-de22125184b8/jobs/11

The commit I used for trigger the above build: https://github.com/lht/cloudwatch_exporter/commit/4a8135dae3654f883f8f2bc9c9ac7fa39e5ab406

Signed-off-by: Haitao Li <lihaitao@gmail.com>