### PR TITLE
Fix Docker builds on linux/arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - ~/.m2
           key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
       - run: mvn package
-  publish_image_to_quay:
+  image:
     docker:
       - image: circleci/openjdk:17-jdk-buster
     environment:
@@ -41,19 +41,27 @@ jobs:
             docker buildx install
             # Run binfmt
             docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+      - run: docker context create buildx
+      - run: docker buildx create --name buildx --use buildx
       - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
       - run: |
-          docker buildx create --use
-          if [[ -n "$CIRCLE_TAG" ]]; then
-            docker buildx build \
-              --platform "$BUILDX_PLATFORMS" \
-              -t quay.io/prometheus/cloudwatch-exporter:"${CIRCLE_TAG}" \
-              -t quay.io/prometheus/cloudwatch-exporter:latest --push .
-          else
-            docker buildx build \
-              --platform "$BUILDX_PLATFORMS" \
-              -t quay.io/prometheus/cloudwatch-exporter:latest --push .
+          tags=()
+          push=()
+          if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+            tags+=(latest)
+            push+=(--push)
+
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              tags+=("${CIRCLE_TAG}")
+            fi
           fi
+
+          set -x
+          docker buildx build \
+            --progress plain \
+            --platform "$BUILDX_PLATFORMS" \
+            "${tags[@]/#/--tag=quay.io/prometheus/cloudwatch-exporter:}" \
+            "${push[@]}" .
       - run: docker images
 workflows:
   version: 2
@@ -63,13 +71,11 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - publish_image_to_quay:
+      - image:
           context: org-context
           requires:
             - build
           filters:
-            branches:
-              only: master
             tags:
               only: /.*/
 orbs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM openjdk:17 as builder
+FROM openjdk:17-jdk-bullseye as builder
+
+RUN mkdir -p /opt/maven
+RUN curl -o /opt/maven.tar.gz -sSfL https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
+RUN echo '1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa  /opt/maven.tar.gz' | shasum -a 512 -c
+RUN tar -x --strip-components=1 -C /opt/maven -f /opt/maven.tar.gz
+ENV PATH /opt/maven/bin:${PATH}
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN apt-get update -qq && apt-get install -qq maven && mvn package && \
-    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
 
-FROM openjdk:17-jre-slim as runner
+# As of Java 13, the default is POSIX_SPAWN, which doesn't seem to work on
+# ARM64: https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
+ENV MAVEN_OPTS "-Djdk.lang.Process.launchMechanism=vfork"
+
+RUN mvn package
+RUN mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
+
+FROM openjdk:17-slim-bullseye as runner
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 EXPOSE 9106
 

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
+          <version>3.0.0-M5</version>
 	  <configuration>
               <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
 	  </configuration>


### PR DESCRIPTION
Follow-up to #372, #374, #363.

Update the base images used in docker builds. Install Maven from the
tarball, apt pulls in the wrong JDK as a dependency.

Set up the context and builder for buildx.

Work around a bug in Java 13+ on linux/arm64 by using the older "vfork"
method. Update the surefire plugin.

Always run the image build, even for PRs, so that we can catch breakage
here before it hits the main branch.

cc @lht 