### PR TITLE
Use the Prometheus customary vX.Y.Z tag format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,12 +148,13 @@
       <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <groupId>org.apache.maven.plugins</groupId>
-          <version>2.5</version>
+          <version>3.0.0-M4</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <useReleaseProfile>false</useReleaseProfile>
             <releaseProfiles>release</releaseProfiles>
             <goals>deploy</goals>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
           </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
instead of prefixing everything with `cloudwatch_exporter-` again.

This is at least one step towards #354.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>