### PR TITLE
Update and unify Docker image tagging scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - ~/.m2
           key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
       - run: mvn package
-  image:
+  publish_image:
     docker:
       - image: circleci/openjdk:17-jdk-buster
     environment:
@@ -43,17 +43,12 @@ jobs:
             docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
       - run: docker context create buildx
       - run: docker buildx create --name buildx --use buildx
-      - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
+      - run: docker login -u "$QUAY_LOGIN" -p "$QUAY_PASSWORD" quay.io
+      - run: docker login -u "$DOCKER_LOGIN" -p "DOCKER_PASSWORD"
       - run: |
-          tags=()
-          push=()
-          if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-            tags+=(latest)
-            push+=(--push)
-
-            if [[ -n "$CIRCLE_TAG" ]]; then
-              tags+=("${CIRCLE_TAG}")
-            fi
+          tags=(master main)
+          if [[ -n "$CIRCLE_TAG" ]]; then
+            tags+=("${CIRCLE_TAG}" latest)
           fi
 
           set -x
@@ -61,8 +56,43 @@ jobs:
             --progress plain \
             --platform "$BUILDX_PLATFORMS" \
             "${tags[@]/#/--tag=quay.io/prometheus/cloudwatch-exporter:}" \
-            "${push[@]}" .
+            "${tags[@]/#/--tag=prom/cloudwatch-exporter:}" \
+            --push .
       - run: docker images
+  build_image:
+    docker:
+      - image: circleci/openjdk:17-jdk-buster
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: "20.10.7"
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64"
+
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+
+            mkdir -p ~/.docker/cli-plugins
+
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+      - run: docker context create buildx
+      - run: docker buildx create --name buildx --use buildx
+      - run: |
+          docker buildx build \
+            --progress plain \
+            --platform "$BUILDX_PLATFORMS" \
+            .
 workflows:
   version: 2
   cloudwatch_exporter:
@@ -71,12 +101,21 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - image:
+      - build_image:
+          context: org-context
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: master
+      - publish_image:
           context: org-context
           requires:
             - build
           filters:
             tags:
               only: /.*/
+            branches:
+              only: master
 orbs:
   prometheus: prometheus/prometheus@0.14.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,4 @@ Prometheus uses GitHub to manage reviews of pull requests.
 
 # Releasing
 
-For release instructions, see the [`java_client` wiki](https://github.com/prometheus/client_java/wiki/Development).
+For release instructions, see [RELEASING](RELEASING.md).

--- a/README.md
+++ b/README.md
@@ -179,26 +179,36 @@ requests (as of Aug 2018), that is around $45 per month. The
 When using the `aws_tag_select` feature, additional requests are made to the Resource Groups Tagging API, but these are [free](https://aws.amazon.com/blogs/aws/new-aws-resource-tagging-api/).
 The `tagging_api_requests_total` counter tracks how many requests are being made for these.
 
-## Docker Image
+## Docker Images
 
-To run the CloudWatch exporter on Docker, you can use the [prom/cloudwatch-exporter](https://hub.docker.com/r/prom/cloudwatch-exporter/)
-image. It exposes port 9106 and expects the config in `/config/config.yml`. To
-configure it, you can bind-mount a config from your host:
+To run the CloudWatch exporter on Docker, you can use the image from
 
-```
-$ docker run -p 9106 -v /path/on/host/config.yml:/config/config.yml prom/cloudwatch-exporter
+* [prom/cloudwatch-exporter](https://hub.docker.com/r/prom/cloudwatch-exporter/)
+* [quay.io/prometheus/cloudwatch-exporter](https://quay.io/repository/prometheus/cloudwatch-exporter)
+
+The available tags are
+
+* `main`: snapshot updated on every push to the main branch
+* `latest`: the latest released version
+* `vX.Y.Z`: the specific version X.Y.Z. Note that up to version 0.11.0, the format was `cloudwatch-exporter_X.Y.Z`.
+
+The image exposes port 9106 and expects the config in `/config/config.yml`.
+To configure it, you can bind-mount a config from your host:
+
+```sh
+docker run -p 9106 -v /path/on/host/config.yml:/config/config.yml quay.io/prometheus/cloudwatch-exporter
 ```
 
 Specify the config as the CMD:
 
-```
-$ docker run -p 9106 -v /path/on/host/us-west-1.yml:/config/us-west-1.yml prom/cloudwatch-exporter /config/us-west-1.yml
+```sh
+docker run -p 9106 -v /path/on/host/us-west-1.yml:/config/us-west-1.yml quay.io/prometheus/cloudwatch-exporter /config/us-west-1.yml
 ```
 
 Or create a config file named `config.yml` along with following
 Dockerfile in the same directory and build it with `docker build`:
 
-```
+```Dockerfile
 FROM prom/cloudwatch-exporter
 ADD config.yml /config/
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,90 @@
+# Releasing the CloudWatch exporter
+
+Only maintainers can do this.
+The process is based on the [`java_client` release process](https://github.com/prometheus/client_java/wiki/Development).
+
+## Requirements
+
+* JDK 11
+* Maven
+* GPG
+
+## Access to the OSS Sonatype repository
+
+Sign up through [Sonatype JIRA](https://issues.sonatype.org) if you don't have an account already.
+[File a Publishing Support ticket](https://central.sonatype.org/faq/get-support/#producers) ([example](https://issues.sonatype.org/browse/OSSRH-70163)) to gain access to the `io.prometheus` group in the Sonatype OSSRH.
+The same login will be used for the repository.
+
+Verify that you can log into [OSSRH](https://https://oss.sonatype.org/).
+The CloudWatch Exporter is at [io.prometheus.cloudwatch](https://oss.sonatype.org/#nexus-search;quick~io.prometheus.cloudwatch).
+
+Set up [Maven publishing](https://central.sonatype.org/publish/publish-maven/), specifically the `<server>` block in `~/.m2/settings.xml`.
+A minimal config:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+  https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>jira-user</username>
+      <password>jira-password</password>
+    </server>
+  </servers>
+</settings>
+```
+
+The project setup is already done.
+
+## Push a snapshot
+
+To push a snapshot, check out the latest main branch and run
+
+```sh
+mvn clean deploy
+```
+
+This should succeed.
+
+## Start a release
+
+To prepare a release:
+
+```sh
+mvn release:clean release:prepare
+```
+
+This will
+
+1. prompt for the version
+2. update `pom.xml` with this version
+3. create and push a git tag
+4. build everything
+5. GPG-sign the artifacts
+
+To actually release:
+
+```sh
+mvn release:perform
+```
+
+This will upload everything to OSSRH into a **staging repository**.
+[Locate it](https://central.sonatype.org/publish/release/#locate-and-examine-your-staging-repository).
+Press "Close" to promote it.
+
+The staging repository will show "Activity: Operation in progress" for a few seconds.
+Refresh or check the Activity tab to see what's going on.
+
+Once closing is done, the "Release" button unlocks.
+Press it.
+
+This runs for a while, and the new version should become available on [OSSRH](https://oss.sonatype.org/#nexus-search;quick~io.prometheus.cloudwatch).
+It can take a few hours to show up.
+
+## Docker images
+
+As part of the release process, `mvn` will create the git tag.
+This tag is picked up by [CircleCI](https://app.circleci.com/pipelines/github/prometheus/cloudwatch_exporter?branch=master), which builds and pushes the [Docker images](README.md#docker-images).


### PR DESCRIPTION
**HOLD** until 2021-11-29

Push images to both Docker Hub and Quay.io.

Only tag releases as `latest`, in line with what we previously did
manually for Docker Hub.

Publish per-release tags, using the tags as chosen by
maven-release-plugin, now `vX.Y.Z` as of #377.

Publish `main` (and `master` for consistency with other Prometheus
projects)

Fixes #354.