### PR TITLE
Use a stable download URL for Maven

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM openjdk:17-jdk-bullseye as builder
 
+ENV MAVEN_VERSION 3.8.3
+ENV MAVEN_SHA512 1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa
+
 RUN mkdir -p /opt/maven
-RUN curl -o /opt/maven.tar.gz -sSfL https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
-RUN echo '1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa  /opt/maven.tar.gz' | shasum -a 512 -c
+RUN curl -o /opt/maven.tar.gz -sSfL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+RUN echo "${MAVEN_SHA512}  /opt/maven.tar.gz" | shasum -a 512 -c
 RUN tar -x --strip-components=1 -C /opt/maven -f /opt/maven.tar.gz
 ENV PATH /opt/maven/bin:${PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:17-jdk-bullseye as builder
 
-ENV MAVEN_VERSION 3.8.3
-ENV MAVEN_SHA512 1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa
+ENV MAVEN_VERSION 3.8.4
+ENV MAVEN_SHA512 a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
 
 RUN mkdir -p /opt/maven
 RUN curl -o /opt/maven.tar.gz -sSfL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz


### PR DESCRIPTION
The Maven project unpublish patch versions from their CDN as soon as
they release a patch version. To avoid breaking the build every time
this happens (and repeated PR rebasing), use the archive URL instead.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>