### PR TITLE
feat: use jlink rather than jdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,5 @@ workflows:
               only: /.*/
             branches:
               only: master
-
 orbs:
   prometheus: prometheus/prometheus@0.14.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     working_directory: ~/circleci-java
     docker:
       - image: circleci/openjdk:17-jdk-buster
+    environment:
+      MAVEN_OPTS: "-Djdk.lang.Process.launchMechanism=vfork"
     steps:
       - checkout
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
@@ -12,22 +14,26 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+            - target
+          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}-{{ .Branch }}
       - run: mvn package
   publish_image:
     docker:
-      - image: circleci/openjdk:17-jdk-buster
+      - image: circleci/openjdk:17-jdk-bullseye
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - checkout
       - setup_remote_docker:
-          version: "20.10.7"
+          version: "20.10.12"
+      - restore_cache:
+          keys:
+            - circleci-demo-java-spring-{{ checksum "pom.xml" }}-{{ .Branch }}
       - run:
           name: Install buildx
           command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64"
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64"
 
             curl --output docker-buildx \
               --silent --show-error --location --fail --retry 3 \
@@ -58,21 +64,37 @@ jobs:
             "${tags[@]/#/--tag=quay.io/prometheus/cloudwatch-exporter:}" \
             "${tags[@]/#/--tag=prom/cloudwatch-exporter:}" \
             --push .
+
+      - run: |
+          tags=(minimal)
+          if [[ -n "$CIRCLE_TAG" ]]; then
+            tags+=("${CIRCLE_TAG}-minimal" latest-minimal)
+          fi
+
+          set -x
+          docker buildx build \
+            --dockerfile Dockerfile-minimal \
+            --progress plain \
+            --platform "$BUILDX_PLATFORMS" \
+            "${tags[@]/#/--tag=quay.io/prometheus/cloudwatch-exporter:}" \
+            "${tags[@]/#/--tag=prom/cloudwatch-exporter:}" \
+            --push .
+
       - run: docker images
   build_image:
     docker:
-      - image: circleci/openjdk:17-jdk-buster
+      - image: circleci/openjdk:17-jdk-bullseye
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - checkout
       - setup_remote_docker:
-          version: "20.10.7"
+          version: "20.10.12"
       - run:
           name: Install buildx
           command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64"
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64"
 
             curl --output docker-buildx \
               --silent --show-error --location --fail --retry 3 \
@@ -90,6 +112,12 @@ jobs:
       - run: docker buildx create --name buildx --use buildx
       - run: |
           docker buildx build \
+            --progress plain \
+            --platform "$BUILDX_PLATFORMS" \
+            .
+      - run: |
+          docker buildx build \
+            --dockerfile Dockerfile-minimal \
             --progress plain \
             --platform "$BUILDX_PLATFORMS" \
             .
@@ -117,5 +145,6 @@ workflows:
               only: /.*/
             branches:
               only: master
+
 orbs:
   prometheus: prometheus/prometheus@0.14.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,13 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - target
-          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}-{{ .Branch }}
+          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
       - run: mvn package
+      - run: mv target/cloudwatch_exporter-*-with-dependencies.jar cloudwatch_exporter.jar
+      - save_cache:
+          paths:
+            - cloudwatch_exporter.jar
+          key: cloudwatch-exporter-jar-{{ .Branch }}
   publish_image:
     docker:
       - image: circleci/openjdk:17-jdk-bullseye
@@ -29,7 +33,7 @@ jobs:
           version: "20.10.12"
       - restore_cache:
           keys:
-            - circleci-demo-java-spring-{{ checksum "pom.xml" }}-{{ .Branch }}
+            - cloudwatch-exporter-jar-{{ .Branch }}
       - run:
           name: Install buildx
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM openjdk:17-jdk-bullseye as builder
 
+SHELL ["/bin/bash", "-xe", "-o", "pipefail", "-c"]
+
 ENV MAVEN_VERSION 3.8.4
 ENV MAVEN_SHA512 a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
 
 RUN mkdir -p /opt/maven
-RUN curl -o /opt/maven.tar.gz -sSfL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+ADD https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+    /opt/maven.tar.gz
 RUN echo "${MAVEN_SHA512}  /opt/maven.tar.gz" | shasum -a 512 -c
 RUN tar -x --strip-components=1 -C /opt/maven -f /opt/maven.tar.gz
 ENV PATH /opt/maven/bin:${PATH}
 
 WORKDIR /cloudwatch_exporter
-ADD . /cloudwatch_exporter
+COPY . /cloudwatch_exporter
 
 # As of Java 13, the default is POSIX_SPAWN, which doesn't seem to work on
 # ARM64: https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
@@ -19,12 +22,25 @@ ENV MAVEN_OPTS "-Djdk.lang.Process.launchMechanism=vfork"
 RUN mvn package
 RUN mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
 
-FROM openjdk:17-slim-bullseye as runner
+RUN jlink \
+        --add-modules java.base,java.desktop,java.logging,java.management,java.naming,jdk.unsupported \
+        --strip-debug \
+        --no-man-pages \
+        --no-header-files \
+        --compress=2 \
+        --output /javaruntime
+
+
+FROM debian:bullseye-slim as runner
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 EXPOSE 9106
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=${JAVA_HOME}/bin:${PATH}
 
 WORKDIR /
 RUN mkdir /config
 COPY --from=builder /cloudwatch_exporter.jar /cloudwatch_exporter.jar
+COPY --from=builder /javaruntime $JAVA_HOME
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106"]
 CMD ["/config/config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,9 @@
-FROM openjdk:17-jdk-bullseye as builder
-
-SHELL ["/bin/bash", "-xe", "-o", "pipefail", "-c"]
-
-ENV MAVEN_VERSION 3.8.4
-ENV MAVEN_SHA512 a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
-
-RUN mkdir -p /opt/maven
-ADD https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-    /opt/maven.tar.gz
-RUN echo "${MAVEN_SHA512}  /opt/maven.tar.gz" | shasum -a 512 -c
-RUN tar -x --strip-components=1 -C /opt/maven -f /opt/maven.tar.gz
-ENV PATH /opt/maven/bin:${PATH}
-
-WORKDIR /cloudwatch_exporter
-COPY . /cloudwatch_exporter
-
-# As of Java 13, the default is POSIX_SPAWN, which doesn't seem to work on
-# ARM64: https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
-ENV MAVEN_OPTS "-Djdk.lang.Process.launchMechanism=vfork"
-
-RUN mvn package
-RUN mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
-
-RUN jlink \
-        --add-modules java.base,java.desktop,java.logging,java.management,java.naming,jdk.unsupported \
-        --strip-debug \
-        --no-man-pages \
-        --no-header-files \
-        --compress=2 \
-        --output /javaruntime
-
-
-FROM debian:bullseye-slim as runner
+FROM openjdk:17-slim-bullseye as runner
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 EXPOSE 9106
 
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH=${JAVA_HOME}/bin:${PATH}
-
 WORKDIR /
 RUN mkdir /config
-COPY --from=builder /cloudwatch_exporter.jar /cloudwatch_exporter.jar
-COPY --from=builder /javaruntime $JAVA_HOME
+COPY cloudwatch_exporter.jar /cloudwatch_exporter.jar
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106"]
 CMD ["/config/config.yml"]

--- a/Dockerfile-minimal
+++ b/Dockerfile-minimal
@@ -1,0 +1,46 @@
+FROM openjdk:17-jdk-bullseye as builder
+
+SHELL ["/bin/bash", "-xe", "-o", "pipefail", "-c"]
+
+ENV MAVEN_VERSION 3.8.4
+ENV MAVEN_SHA512 a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
+
+RUN mkdir -p /opt/maven
+ADD https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+    /opt/maven.tar.gz
+RUN echo "${MAVEN_SHA512}  /opt/maven.tar.gz" | shasum -a 512 -c
+RUN tar -x --strip-components=1 -C /opt/maven -f /opt/maven.tar.gz
+ENV PATH /opt/maven/bin:${PATH}
+
+WORKDIR /cloudwatch_exporter
+COPY . /cloudwatch_exporter
+
+# As of Java 13, the default is POSIX_SPAWN, which doesn't seem to work on
+# ARM64: https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
+ENV MAVEN_OPTS "-Djdk.lang.Process.launchMechanism=vfork"
+
+RUN mvn package
+RUN mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
+
+RUN jlink \
+        --add-modules java.base,java.desktop,java.logging,java.management,java.naming,jdk.unsupported \
+        --strip-debug \
+        --no-man-pages \
+        --no-header-files \
+        --compress=2 \
+        --output /javaruntime
+
+
+FROM debian:bullseye-slim as runner
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+EXPOSE 9106
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+WORKDIR /
+RUN mkdir /config
+COPY cloudwatch_exporter.jar /cloudwatch_exporter.jar
+COPY --from=builder /javaruntime $JAVA_HOME
+ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106"]
+CMD ["/config/config.yml"]

--- a/Dockerfile-minimal
+++ b/Dockerfile-minimal
@@ -1,27 +1,5 @@
 FROM openjdk:17-jdk-bullseye as builder
 
-SHELL ["/bin/bash", "-xe", "-o", "pipefail", "-c"]
-
-ENV MAVEN_VERSION 3.8.4
-ENV MAVEN_SHA512 a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
-
-RUN mkdir -p /opt/maven
-ADD https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-    /opt/maven.tar.gz
-RUN echo "${MAVEN_SHA512}  /opt/maven.tar.gz" | shasum -a 512 -c
-RUN tar -x --strip-components=1 -C /opt/maven -f /opt/maven.tar.gz
-ENV PATH /opt/maven/bin:${PATH}
-
-WORKDIR /cloudwatch_exporter
-COPY . /cloudwatch_exporter
-
-# As of Java 13, the default is POSIX_SPAWN, which doesn't seem to work on
-# ARM64: https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
-ENV MAVEN_OPTS "-Djdk.lang.Process.launchMechanism=vfork"
-
-RUN mvn package
-RUN mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar
-
 RUN jlink \
         --add-modules java.base,java.desktop,java.logging,java.management,java.naming,jdk.unsupported \
         --strip-debug \


### PR DESCRIPTION
It makes the final image smaller.

- 221MB, https://hub.docker.com/layers/prom/cloudwatch-exporter/latest/images/sha256-6a5afd6d7f1cbc90bfea77f0b92942d57422f9a91d441bb293837693a388e867?context=explore
- 71MB, https://hub.docker.com/layers/greut/cloudwatch_exporter/latest/images/sha256-b455dea048b56ad3ce98b2a43669b42a89df9c09aab0099355283d84790180b0?context=explore