### PR TITLE
Improve health and ready endpoints

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -7,11 +7,20 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class HealthServlet extends HttpServlet {
-	private static final long serialVersionUID = 5543118274931292897L;
+  private static final long serialVersionUID = 5543118274931292897L;
+  private final CloudWatchCollector collector;
 
-	@Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setContentType("text/plain");
-        resp.getWriter().print("ok");
+  public HealthServlet(CloudWatchCollector collector) {
+    this.collector = collector;
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    if (this.collector.hasError()) {
+      resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    } else {
+      resp.setContentType("text/plain");
+      resp.getWriter().print("ok");
     }
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -35,8 +35,8 @@ public class WebServer {
         server.setHandler(context);
         context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
         context.addServlet(new ServletHolder(new DynamicReloadServlet(collector)), "/-/reload");
-        context.addServlet(new ServletHolder(new HealthServlet()), "/-/healthy");
-        context.addServlet(new ServletHolder(new HealthServlet()), "/-/ready");
+        context.addServlet(new ServletHolder(new HealthServlet(collector)), "/-/healthy");
+        context.addServlet(new ServletHolder(new HealthServlet(collector)), "/-/ready");
         context.addServlet(new ServletHolder(new HomePageServlet()), "/");
         server.start();
         server.join();


### PR DESCRIPTION
This PR changes the health endpoints so they reflect the latest status of the collector.

Recently during an AWS outage our cloudwatch metrics exporter (running in kubernetes) broke because the outage caused permissions to invalidate which meant the collector could no longer access the AWS api. 

The solution was to manually delete the pod however it would have been great if the liveness endpoint had detected the problem so it could have resolved the situation automatically. This PR should help with that.