### PR TITLE
Add config builder link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ metrics:
 ```
 **Note:** configuration examples for different namespaces can be found in [examples](./examples) directory
 
+**Note:** A configuration builder can be found [here](https://github.com/djloude/cloudwatch_exporter_metrics_config_builder/blob/main/README.md).
+
 Name     | Description
 ---------|------------
 region   | Optional. The AWS region to connect to. If none is provided, an attempt will be made to determine the region from the [default region provider chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html#default-region-provider-chain).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ metrics:
 ```
 **Note:** configuration examples for different namespaces can be found in [examples](./examples) directory
 
-**Note:** A configuration builder can be found [here](https://github.com/djloude/cloudwatch_exporter_metrics_config_builder/blob/main/README.md).
+**Note:** A configuration builder can be found [here](https://github.com/djloude/cloudwatch_exporter_metrics_config_builder).
 
 Name     | Description
 ---------|------------


### PR DESCRIPTION
Modified some recent infrastructure as code that utilized this cloudwatch exporter that could help solve issues https://github.com/prometheus/cloudwatch_exporter/issues/356 & https://github.com/prometheus/cloudwatch_exporter/issues/356.
I added a comment linking to the source code for the builder and @matthiasr suggested a PR to add a link to the README.md