### PR TITLE
Remove org-context from PR Docker Image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ workflows:
             tags:
               only: /.*/
       - build_image:
-          context: org-context
           requires:
             - build
           filters:


### PR DESCRIPTION
This context prevented the build from running for external contributors,
but it is not needed as the PR build explicitly does not log in to the
Docker registries.

Missed this bit in 77c930795c3ade6f29072a92f0cf842e84f69d7e.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>