### PR TITLE
build: update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,17 +46,22 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>cloudwatch</artifactId>
-      <version>2.17.100</version>
+      <version>2.17.170</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.17.100</version>
+      <version>2.17.170</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>resourcegroupstaggingapi</artifactId>
-      <version>2.17.100</version>
+      <version>2.17.170</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -73,7 +78,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -98,7 +103,7 @@
     <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>10.0.7</version>
+        <version>10.0.8</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
updating these dependencies to close some security vulnerabilities detected on quay and other platform:
VULNDB-275302
VULNDB-283441
SNYK-JAVA-COMMONSCODEC-561518
SNYK-JAVA-IONETTY-2314893
SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698
SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244

Signed-off-by: Adhi Sutandi <adhi.sutandi@beekeeper.io>