### PR TITLE
Added automatic code formatter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,16 @@ jobs:
           paths:
             - ~/.m2
           key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+      - run: 
+          name: Check formatting
+          command: |
+            if (mvn fmt:check);
+            then
+              echo "Code is well formatted"
+            else
+              echo "Code is not formatted well. Please run 'mvn fmt:format' and commit changes"
+              exit 1
+            fi 
       - run: mvn package
   publish_image:
     docker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,11 @@ Prometheus uses GitHub to manage reviews of pull requests.
   This will avoid unnecessary work and surely give you and us a good deal
   of inspiration.
 
+### Formatting
+- IDEs differ in how they format Java code. This can generate a lot of unrelated code change. To avoid this - we enforce specific formatting.
+- Code is automatically formatted with [Spotify fmt maven-plugin](https://github.com/spotify/fmt-maven-plugin) whenever you run standard `mvn install`.
+- CI builds will fail if code is not formatted that way.
+- To simply run the formatter you can always run: `mvn fmt:format` (requires JVM > 11)
 # Releasing
 
 For release instructions, see [RELEASING](RELEASING.md).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For a different approach to CloudWatch metrics, with automatic discovery, consid
 
 ## Building and running
 
-Cloudwatch Exporter requires at least Java 8.
+Cloudwatch Exporter requires at least Java 11.
 
 `mvn package` to build.
 

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,18 @@
               </execution>
           </executions>
       </plugin>
+      <plugin>
+        <groupId>com.spotify.fmt</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.18</version>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>format</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/io/prometheus/cloudwatch/BuildInfoCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/BuildInfoCollector.java
@@ -1,7 +1,6 @@
 package io.prometheus.cloudwatch;
 
 import io.prometheus.client.Collector;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,40 +9,45 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class BuildInfoCollector extends Collector {
-    private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
-    public List<MetricFamilySamples> collect() {
-        List<MetricFamilySamples> mfs = new ArrayList<>();
-        List<MetricFamilySamples.Sample> samples;
-        List<String> labelNames = new ArrayList<>();
-        List<String> labelValues = new ArrayList<>();
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<>();
+    List<MetricFamilySamples.Sample> samples;
+    List<String> labelNames = new ArrayList<>();
+    List<String> labelValues = new ArrayList<>();
 
-        String buildVersion = "";
-        String releaseDate = "";
-        try {
-            final Properties properties = new Properties();
-            properties.load(CloudWatchCollector.class.getClassLoader().getResourceAsStream(".properties"));
-            buildVersion = properties.getProperty("BuildVersion");
-            releaseDate = properties.getProperty("ReleaseDate");
+    String buildVersion = "";
+    String releaseDate = "";
+    try {
+      final Properties properties = new Properties();
+      properties.load(
+          CloudWatchCollector.class.getClassLoader().getResourceAsStream(".properties"));
+      buildVersion = properties.getProperty("BuildVersion");
+      releaseDate = properties.getProperty("ReleaseDate");
 
-        }
-        catch (IOException e) {
-            buildVersion = "unknown";
-            releaseDate = "unknown";
-            LOGGER.log(Level.WARNING, "CloudWatch build info scrape failed", e);
-        }
-
-        labelNames.add("build_version");
-        labelValues.add(buildVersion);
-        labelNames.add("release_date");
-        labelValues.add(releaseDate);
-
-        samples = new ArrayList<>();
-        samples.add(new MetricFamilySamples.Sample(
-                "cloudwatch_exporter_build_info", labelNames, labelValues, 1));
-        mfs.add(new MetricFamilySamples("cloudwatch_exporter_build_info",
-                Type.GAUGE, "Non-zero if build info scrape failed.", samples));
-
-        return mfs;
+    } catch (IOException e) {
+      buildVersion = "unknown";
+      releaseDate = "unknown";
+      LOGGER.log(Level.WARNING, "CloudWatch build info scrape failed", e);
     }
+
+    labelNames.add("build_version");
+    labelValues.add(buildVersion);
+    labelNames.add("release_date");
+    labelValues.add(releaseDate);
+
+    samples = new ArrayList<>();
+    samples.add(
+        new MetricFamilySamples.Sample(
+            "cloudwatch_exporter_build_info", labelNames, labelValues, 1));
+    mfs.add(
+        new MetricFamilySamples(
+            "cloudwatch_exporter_build_info",
+            Type.GAUGE,
+            "Non-zero if build info scrape failed.",
+            samples));
+
+    return mfs;
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -2,26 +2,24 @@ package io.prometheus.cloudwatch;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.Collector.Describable;
-import io.prometheus.cloudwatch.DataGetter.MetricRuleData;
 import io.prometheus.client.Counter;
+import io.prometheus.cloudwatch.DataGetter.MetricRuleData;
 import java.io.FileReader;
-import java.io.Reader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.Map.Entry;
-import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
 import org.yaml.snakeyaml.Yaml;
-
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
@@ -44,681 +42,799 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class CloudWatchCollector extends Collector implements Describable {
-    private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
-    static class ActiveConfig {
-        ArrayList<MetricRule> rules;
-        CloudWatchClient cloudWatchClient;
-        ResourceGroupsTaggingApiClient taggingClient;
+  static class ActiveConfig {
+    ArrayList<MetricRule> rules;
+    CloudWatchClient cloudWatchClient;
+    ResourceGroupsTaggingApiClient taggingClient;
 
-        public ActiveConfig(ActiveConfig cfg) {
-            this.rules = new ArrayList<>(cfg.rules);
-            this.cloudWatchClient = cfg.cloudWatchClient;
-            this.taggingClient = cfg.taggingClient;
+    public ActiveConfig(ActiveConfig cfg) {
+      this.rules = new ArrayList<>(cfg.rules);
+      this.cloudWatchClient = cfg.cloudWatchClient;
+      this.taggingClient = cfg.taggingClient;
+    }
+
+    public ActiveConfig() {}
+  }
+
+  static class MetricRule {
+    String awsNamespace;
+    String awsMetricName;
+    int periodSeconds;
+    int rangeSeconds;
+    int delaySeconds;
+    List<Statistic> awsStatistics;
+    List<String> awsExtendedStatistics;
+    List<String> awsDimensions;
+    Map<String, List<String>> awsDimensionSelect;
+    Map<String, List<String>> awsDimensionSelectRegex;
+    AWSTagSelect awsTagSelect;
+    String help;
+    boolean cloudwatchTimestamp;
+    boolean useGetMetricData;
+  }
+
+  static class AWSTagSelect {
+    String resourceTypeSelection;
+    String resourceIdDimension;
+    Map<String, List<String>> tagSelections;
+  }
+
+  ActiveConfig activeConfig = new ActiveConfig();
+
+  private static final Counter cloudwatchRequests =
+      Counter.build()
+          .labelNames("action", "namespace")
+          .name("cloudwatch_requests_total")
+          .help("API requests made to CloudWatch")
+          .register();
+
+  private static final Counter cloudwatchMetricsRequsted =
+      Counter.build()
+          .labelNames("metric_name", "namespace")
+          .name("cloudwatch_metrics_requsted_total")
+          .help("Metrics requested by either GetMetricStatistics or GetMetricData")
+          .register();
+
+  private static final Counter taggingApiRequests =
+      Counter.build()
+          .labelNames("action", "resource_type")
+          .name("tagging_api_requests_total")
+          .help("API requests made to the Resource Groups Tagging API")
+          .register();
+
+  private static final List<String> brokenDynamoMetrics =
+      Arrays.asList(
+          "ConsumedReadCapacityUnits", "ConsumedWriteCapacityUnits",
+          "ProvisionedReadCapacityUnits", "ProvisionedWriteCapacityUnits",
+          "ReadThrottleEvents", "WriteThrottleEvents");
+
+  public CloudWatchCollector(Reader in) {
+    loadConfig(in, null, null);
+  }
+
+  public CloudWatchCollector(String yamlConfig) {
+    this((Map<String, Object>) new Yaml().load(yamlConfig), null, null);
+  }
+
+  /* For unittests. */
+  protected CloudWatchCollector(
+      String jsonConfig,
+      CloudWatchClient cloudWatchClient,
+      ResourceGroupsTaggingApiClient taggingClient) {
+    this((Map<String, Object>) new Yaml().load(jsonConfig), cloudWatchClient, taggingClient);
+  }
+
+  private CloudWatchCollector(
+      Map<String, Object> config,
+      CloudWatchClient cloudWatchClient,
+      ResourceGroupsTaggingApiClient taggingClient) {
+    loadConfig(config, cloudWatchClient, taggingClient);
+  }
+
+  @Override
+  public List<MetricFamilySamples> describe() {
+    return Collections.emptyList();
+  }
+
+  protected void reloadConfig() throws IOException {
+    LOGGER.log(Level.INFO, "Reloading configuration");
+    try (FileReader reader = new FileReader(WebServer.configFilePath); ) {
+      loadConfig(reader, activeConfig.cloudWatchClient, activeConfig.taggingClient);
+    }
+  }
+
+  protected void loadConfig(
+      Reader in, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
+    loadConfig((Map<String, Object>) new Yaml().load(in), cloudWatchClient, taggingClient);
+  }
+
+  private void loadConfig(
+      Map<String, Object> config,
+      CloudWatchClient cloudWatchClient,
+      ResourceGroupsTaggingApiClient taggingClient) {
+    if (config == null) { // Yaml config empty, set config to empty map.
+      config = new HashMap<>();
+    }
+
+    int defaultPeriod = 60;
+    if (config.containsKey("period_seconds")) {
+      defaultPeriod = ((Number) config.get("period_seconds")).intValue();
+    }
+    int defaultRange = 600;
+    if (config.containsKey("range_seconds")) {
+      defaultRange = ((Number) config.get("range_seconds")).intValue();
+    }
+    int defaultDelay = 600;
+    if (config.containsKey("delay_seconds")) {
+      defaultDelay = ((Number) config.get("delay_seconds")).intValue();
+    }
+
+    boolean defaultCloudwatchTimestamp = true;
+    if (config.containsKey("set_timestamp")) {
+      defaultCloudwatchTimestamp = (Boolean) config.get("set_timestamp");
+    }
+
+    boolean defaultUseGetMetricData = false;
+    if (config.containsKey("use_get_metric_data")) {
+      defaultUseGetMetricData = (Boolean) config.get("use_get_metric_data");
+    }
+
+    String region = (String) config.get("region");
+
+    if (cloudWatchClient == null) {
+      CloudWatchClientBuilder clientBuilder = CloudWatchClient.builder();
+
+      if (config.containsKey("role_arn")) {
+        clientBuilder.credentialsProvider(getRoleCredentialProvider(config));
+      }
+
+      if (region != null) {
+        clientBuilder.region(Region.of(region));
+      }
+
+      cloudWatchClient = clientBuilder.build();
+    }
+
+    if (taggingClient == null) {
+      ResourceGroupsTaggingApiClientBuilder clientBuilder =
+          ResourceGroupsTaggingApiClient.builder();
+
+      if (config.containsKey("role_arn")) {
+        clientBuilder.credentialsProvider(getRoleCredentialProvider(config));
+      }
+      if (region != null) {
+        clientBuilder.region(Region.of(region));
+      }
+      taggingClient = clientBuilder.build();
+    }
+
+    if (!config.containsKey("metrics")) {
+      throw new IllegalArgumentException("Must provide metrics");
+    }
+
+    ArrayList<MetricRule> rules = new ArrayList<>();
+
+    for (Object ruleObject : (List<Map<String, Object>>) config.get("metrics")) {
+      Map<String, Object> yamlMetricRule = (Map<String, Object>) ruleObject;
+      MetricRule rule = new MetricRule();
+      rules.add(rule);
+      if (!yamlMetricRule.containsKey("aws_namespace")
+          || !yamlMetricRule.containsKey("aws_metric_name")) {
+        throw new IllegalArgumentException("Must provide aws_namespace and aws_metric_name");
+      }
+      rule.awsNamespace = (String) yamlMetricRule.get("aws_namespace");
+      rule.awsMetricName = (String) yamlMetricRule.get("aws_metric_name");
+      if (yamlMetricRule.containsKey("help")) {
+        rule.help = (String) yamlMetricRule.get("help");
+      }
+      if (yamlMetricRule.containsKey("aws_dimensions")) {
+        rule.awsDimensions = (List<String>) yamlMetricRule.get("aws_dimensions");
+      }
+      if (yamlMetricRule.containsKey("aws_dimension_select")
+          && yamlMetricRule.containsKey("aws_dimension_select_regex")) {
+        throw new IllegalArgumentException(
+            "Must not provide aws_dimension_select and aws_dimension_select_regex at the same time");
+      }
+      if (yamlMetricRule.containsKey("aws_dimension_select")) {
+        rule.awsDimensionSelect =
+            (Map<String, List<String>>) yamlMetricRule.get("aws_dimension_select");
+      }
+      if (yamlMetricRule.containsKey("aws_dimension_select_regex")) {
+        rule.awsDimensionSelectRegex =
+            (Map<String, List<String>>) yamlMetricRule.get("aws_dimension_select_regex");
+      }
+      if (yamlMetricRule.containsKey("aws_statistics")) {
+        rule.awsStatistics = new ArrayList<>();
+        for (String statistic : (List<String>) yamlMetricRule.get("aws_statistics")) {
+          rule.awsStatistics.add(Statistic.fromValue(statistic));
         }
-
-        public ActiveConfig() {
+      } else if (!yamlMetricRule.containsKey("aws_extended_statistics")) {
+        rule.awsStatistics = new ArrayList<>();
+        for (String statistic :
+            Arrays.asList("Sum", "SampleCount", "Minimum", "Maximum", "Average")) {
+          rule.awsStatistics.add(Statistic.fromValue(statistic));
         }
+      }
+      if (yamlMetricRule.containsKey("aws_extended_statistics")) {
+        rule.awsExtendedStatistics = (List<String>) yamlMetricRule.get("aws_extended_statistics");
+      }
+      if (yamlMetricRule.containsKey("period_seconds")) {
+        rule.periodSeconds = ((Number) yamlMetricRule.get("period_seconds")).intValue();
+      } else {
+        rule.periodSeconds = defaultPeriod;
+      }
+      if (yamlMetricRule.containsKey("range_seconds")) {
+        rule.rangeSeconds = ((Number) yamlMetricRule.get("range_seconds")).intValue();
+      } else {
+        rule.rangeSeconds = defaultRange;
+      }
+      if (yamlMetricRule.containsKey("delay_seconds")) {
+        rule.delaySeconds = ((Number) yamlMetricRule.get("delay_seconds")).intValue();
+      } else {
+        rule.delaySeconds = defaultDelay;
+      }
+      if (yamlMetricRule.containsKey("set_timestamp")) {
+        rule.cloudwatchTimestamp = (Boolean) yamlMetricRule.get("set_timestamp");
+      } else {
+        rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
+      }
+      if (yamlMetricRule.containsKey("use_get_metric_data")) {
+        rule.useGetMetricData = (Boolean) yamlMetricRule.get("use_get_metric_data");
+      } else {
+        rule.useGetMetricData = defaultUseGetMetricData;
+      }
+
+      if (yamlMetricRule.containsKey("aws_tag_select")) {
+        Map<String, Object> yamlAwsTagSelect =
+            (Map<String, Object>) yamlMetricRule.get("aws_tag_select");
+        if (!yamlAwsTagSelect.containsKey("resource_type_selection")
+            || !yamlAwsTagSelect.containsKey("resource_id_dimension")) {
+          throw new IllegalArgumentException(
+              "Must provide resource_type_selection and resource_id_dimension");
+        }
+        AWSTagSelect awsTagSelect = new AWSTagSelect();
+        rule.awsTagSelect = awsTagSelect;
+
+        awsTagSelect.resourceTypeSelection =
+            (String) yamlAwsTagSelect.get("resource_type_selection");
+        awsTagSelect.resourceIdDimension = (String) yamlAwsTagSelect.get("resource_id_dimension");
+
+        if (yamlAwsTagSelect.containsKey("tag_selections")) {
+          awsTagSelect.tagSelections =
+              (Map<String, List<String>>) yamlAwsTagSelect.get("tag_selections");
+        }
+      }
     }
 
-    static class MetricRule {
-      String awsNamespace;
-      String awsMetricName;
-      int periodSeconds;
-      int rangeSeconds;
-      int delaySeconds;
-      List<Statistic> awsStatistics;
-      List<String> awsExtendedStatistics;
-      List<String> awsDimensions;
-      Map<String,List<String>> awsDimensionSelect;
-      Map<String,List<String>> awsDimensionSelectRegex;
-      AWSTagSelect awsTagSelect;
-      String help;
-      boolean cloudwatchTimestamp;
-      boolean useGetMetricData;
+    loadConfig(rules, cloudWatchClient, taggingClient);
+  }
+
+  private void loadConfig(
+      ArrayList<MetricRule> rules,
+      CloudWatchClient cloudWatchClient,
+      ResourceGroupsTaggingApiClient taggingClient) {
+    synchronized (activeConfig) {
+      activeConfig.cloudWatchClient = cloudWatchClient;
+      activeConfig.taggingClient = taggingClient;
+      activeConfig.rules = rules;
     }
+  }
 
-    static class AWSTagSelect {
-      String resourceTypeSelection;
-      String resourceIdDimension;
-      Map<String,List<String>> tagSelections;
-    }
+  private AwsCredentialsProvider getRoleCredentialProvider(Map<String, Object> config) {
+    StsClient stsClient =
+        StsClient.builder().region(Region.of((String) config.get("region"))).build();
+    AssumeRoleRequest assumeRoleRequest =
+        AssumeRoleRequest.builder()
+            .roleArn((String) config.get("role_arn"))
+            .roleSessionName("cloudwatch_exporter")
+            .build();
+    return StsAssumeRoleCredentialsProvider.builder()
+        .stsClient(stsClient)
+        .refreshRequest(assumeRoleRequest)
+        .build();
+  }
 
-    ActiveConfig activeConfig = new ActiveConfig();
-
-    private static final Counter cloudwatchRequests = Counter.build()
-            .labelNames("action", "namespace")
-            .name("cloudwatch_requests_total").help("API requests made to CloudWatch").register();
-
-    private static final Counter cloudwatchMetricsRequsted = Counter.build()
-            .labelNames("metric_name", "namespace")
-            .name("cloudwatch_metrics_requsted_total").help("Metrics requested by either GetMetricStatistics or GetMetricData").register();
-
-    private static final Counter taggingApiRequests = Counter.build()
-        .labelNames("action", "resource_type")
-        .name("tagging_api_requests_total").help("API requests made to the Resource Groups Tagging API").register();
-
-    private static final List<String> brokenDynamoMetrics = Arrays.asList(
-            "ConsumedReadCapacityUnits", "ConsumedWriteCapacityUnits",
-            "ProvisionedReadCapacityUnits", "ProvisionedWriteCapacityUnits",
-            "ReadThrottleEvents", "WriteThrottleEvents");
-
-    public CloudWatchCollector(Reader in) {
-        loadConfig(in, null, null);
-    }
-    public CloudWatchCollector(String yamlConfig) {
-        this((Map<String, Object>)new Yaml().load(yamlConfig), null, null);
-    }
-
-    /* For unittests. */
-    protected CloudWatchCollector(String jsonConfig, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
-        this((Map<String, Object>)new Yaml().load(jsonConfig), cloudWatchClient, taggingClient);
-    }
-
-    private CloudWatchCollector(Map<String, Object> config, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
-        loadConfig(config, cloudWatchClient, taggingClient);
-    }
-
-    @Override
-    public List<MetricFamilySamples> describe() {
+  private List<ResourceTagMapping> getResourceTagMappings(
+      MetricRule rule, ResourceGroupsTaggingApiClient taggingClient) {
+    if (rule.awsTagSelect == null) {
       return Collections.emptyList();
     }
 
-    protected void reloadConfig() throws IOException {
-        LOGGER.log(Level.INFO, "Reloading configuration");
-        try (
-          FileReader reader = new FileReader(WebServer.configFilePath);
-        ) {
-          loadConfig(reader, activeConfig.cloudWatchClient, activeConfig.taggingClient);
-        }
-    }
-
-    protected void loadConfig(Reader in, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
-        loadConfig((Map<String, Object>)new Yaml().load(in), cloudWatchClient, taggingClient);
-    }
-
-    private void loadConfig(Map<String, Object> config, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
-        if(config == null) {  // Yaml config empty, set config to empty map.
-            config = new HashMap<>();
-        }
-
-        int defaultPeriod = 60;
-        if (config.containsKey("period_seconds")) {
-          defaultPeriod = ((Number)config.get("period_seconds")).intValue();
-        }
-        int defaultRange = 600;
-        if (config.containsKey("range_seconds")) {
-          defaultRange = ((Number)config.get("range_seconds")).intValue();
-        }
-        int defaultDelay = 600;
-        if (config.containsKey("delay_seconds")) {
-          defaultDelay = ((Number)config.get("delay_seconds")).intValue();
-        }
-
-        boolean defaultCloudwatchTimestamp = true;
-        if (config.containsKey("set_timestamp")) {
-            defaultCloudwatchTimestamp = (Boolean)config.get("set_timestamp");
-        }
-
-        boolean defaultUseGetMetricData = false;
-        if (config.containsKey("use_get_metric_data")) {
-          defaultUseGetMetricData = (Boolean)config.get("use_get_metric_data");
-        }
-
-        String region = (String) config.get("region");
-
-        if (cloudWatchClient == null) {
-          CloudWatchClientBuilder clientBuilder = CloudWatchClient.builder();
-
-          if (config.containsKey("role_arn")) {
-            clientBuilder.credentialsProvider(getRoleCredentialProvider(config));
-          }
-
-          if (region != null) {
-            clientBuilder.region(Region.of(region));
-          }
-
-          cloudWatchClient = clientBuilder.build();
-        }
-
-        if (taggingClient == null) {
-          ResourceGroupsTaggingApiClientBuilder clientBuilder = ResourceGroupsTaggingApiClient.builder();
-
-          if (config.containsKey("role_arn")) {
-            clientBuilder.credentialsProvider(getRoleCredentialProvider(config));
-          }
-          if (region != null) {
-            clientBuilder.region(Region.of(region));
-          }
-          taggingClient = clientBuilder.build();
-        }
-
-        if (!config.containsKey("metrics")) {
-          throw new IllegalArgumentException("Must provide metrics");
-        }
-
-        ArrayList<MetricRule> rules = new ArrayList<>();
-
-        for (Object ruleObject : (List<Map<String,Object>>) config.get("metrics")) {
-          Map<String, Object> yamlMetricRule = (Map<String, Object>)ruleObject;
-          MetricRule rule = new MetricRule();
-          rules.add(rule);
-          if (!yamlMetricRule.containsKey("aws_namespace") || !yamlMetricRule.containsKey("aws_metric_name")) {
-            throw new IllegalArgumentException("Must provide aws_namespace and aws_metric_name");
-          }
-          rule.awsNamespace = (String)yamlMetricRule.get("aws_namespace");
-          rule.awsMetricName = (String)yamlMetricRule.get("aws_metric_name");
-          if (yamlMetricRule.containsKey("help")) {
-            rule.help = (String)yamlMetricRule.get("help");
-          }
-          if (yamlMetricRule.containsKey("aws_dimensions")) {
-            rule.awsDimensions = (List<String>)yamlMetricRule.get("aws_dimensions");
-          }
-          if (yamlMetricRule.containsKey("aws_dimension_select") && yamlMetricRule.containsKey("aws_dimension_select_regex")) {
-            throw new IllegalArgumentException("Must not provide aws_dimension_select and aws_dimension_select_regex at the same time");
-          }
-          if (yamlMetricRule.containsKey("aws_dimension_select")) {
-            rule.awsDimensionSelect = (Map<String, List<String>>)yamlMetricRule.get("aws_dimension_select");
-          }
-          if (yamlMetricRule.containsKey("aws_dimension_select_regex")) {
-            rule.awsDimensionSelectRegex = (Map<String,List<String>>)yamlMetricRule.get("aws_dimension_select_regex");
-          }
-          if (yamlMetricRule.containsKey("aws_statistics")) {
-            rule.awsStatistics = new ArrayList<>();
-            for (String statistic : (List<String>)yamlMetricRule.get("aws_statistics")) {
-              rule.awsStatistics.add(Statistic.fromValue(statistic));
-            }
-          } else if (!yamlMetricRule.containsKey("aws_extended_statistics")) {
-            rule.awsStatistics = new ArrayList<>();
-            for (String statistic : Arrays.asList("Sum", "SampleCount", "Minimum", "Maximum", "Average")) {
-              rule.awsStatistics.add(Statistic.fromValue(statistic));
-            }
-          }
-          if (yamlMetricRule.containsKey("aws_extended_statistics")) {
-            rule.awsExtendedStatistics = (List<String>)yamlMetricRule.get("aws_extended_statistics");
-          }
-          if (yamlMetricRule.containsKey("period_seconds")) {
-            rule.periodSeconds = ((Number)yamlMetricRule.get("period_seconds")).intValue();
-          } else {
-            rule.periodSeconds = defaultPeriod;
-          }
-          if (yamlMetricRule.containsKey("range_seconds")) {
-            rule.rangeSeconds = ((Number)yamlMetricRule.get("range_seconds")).intValue();
-          } else {
-            rule.rangeSeconds = defaultRange;
-          }
-          if (yamlMetricRule.containsKey("delay_seconds")) {
-            rule.delaySeconds = ((Number)yamlMetricRule.get("delay_seconds")).intValue();
-          } else {
-            rule.delaySeconds = defaultDelay;
-          }
-          if (yamlMetricRule.containsKey("set_timestamp")) {
-              rule.cloudwatchTimestamp = (Boolean)yamlMetricRule.get("set_timestamp");
-          } else {
-              rule.cloudwatchTimestamp = defaultCloudwatchTimestamp;
-          }
-          if (yamlMetricRule.containsKey("use_get_metric_data")) {
-            rule.useGetMetricData = (Boolean)yamlMetricRule.get("use_get_metric_data");
-          } else {
-            rule.useGetMetricData = defaultUseGetMetricData;
-          }
-
-          if (yamlMetricRule.containsKey("aws_tag_select")) {
-            Map<String, Object> yamlAwsTagSelect = (Map<String, Object>) yamlMetricRule.get("aws_tag_select");
-            if (!yamlAwsTagSelect.containsKey("resource_type_selection") || !yamlAwsTagSelect.containsKey("resource_id_dimension")) {
-              throw new IllegalArgumentException("Must provide resource_type_selection and resource_id_dimension");
-            }
-            AWSTagSelect awsTagSelect = new AWSTagSelect();
-            rule.awsTagSelect = awsTagSelect;
-
-            awsTagSelect.resourceTypeSelection = (String)yamlAwsTagSelect.get("resource_type_selection");
-            awsTagSelect.resourceIdDimension = (String)yamlAwsTagSelect.get("resource_id_dimension");
-
-            if (yamlAwsTagSelect.containsKey("tag_selections")) {
-              awsTagSelect.tagSelections = (Map<String, List<String>>)yamlAwsTagSelect.get("tag_selections");
-            }
-          }
-        }
-
-        loadConfig(rules, cloudWatchClient, taggingClient);
-    }
-
-    private void loadConfig(ArrayList<MetricRule> rules, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
-        synchronized (activeConfig) {
-            activeConfig.cloudWatchClient = cloudWatchClient;
-            activeConfig.taggingClient = taggingClient;
-            activeConfig.rules = rules;
-        }
-    }
-
-    private AwsCredentialsProvider getRoleCredentialProvider(Map<String, Object> config) {
-      StsClient stsClient = StsClient.builder().region(Region.of((String) config.get("region"))).build();
-      AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
-              .roleArn((String) config.get("role_arn"))
-              .roleSessionName("cloudwatch_exporter").build();
-      return StsAssumeRoleCredentialsProvider.builder()
-              .stsClient(stsClient)
-              .refreshRequest(assumeRoleRequest).build();
-    }
-
-    private List<ResourceTagMapping> getResourceTagMappings(MetricRule rule, ResourceGroupsTaggingApiClient taggingClient) {
-      if (rule.awsTagSelect == null) {
-        return Collections.emptyList();
+    List<TagFilter> tagFilters = new ArrayList<>();
+    if (rule.awsTagSelect.tagSelections != null) {
+      for (Map.Entry<String, List<String>> entry : rule.awsTagSelect.tagSelections.entrySet()) {
+        tagFilters.add(TagFilter.builder().key(entry.getKey()).values(entry.getValue()).build());
       }
+    }
 
-      List<TagFilter> tagFilters = new ArrayList<>();
-      if (rule.awsTagSelect.tagSelections != null) {
-        for (Map.Entry<String, List<String>> entry : rule.awsTagSelect.tagSelections.entrySet()) {
-          tagFilters.add(TagFilter.builder().key(entry.getKey()).values(entry.getValue()).build());
+    List<ResourceTagMapping> resourceTagMappings = new ArrayList<>();
+    GetResourcesRequest.Builder requestBuilder =
+        GetResourcesRequest.builder()
+            .tagFilters(tagFilters)
+            .resourceTypeFilters(rule.awsTagSelect.resourceTypeSelection);
+    String paginationToken = "";
+    do {
+      requestBuilder.paginationToken(paginationToken);
+
+      GetResourcesResponse response = taggingClient.getResources(requestBuilder.build());
+      taggingApiRequests.labels("getResources", rule.awsTagSelect.resourceTypeSelection).inc();
+
+      resourceTagMappings.addAll(response.resourceTagMappingList());
+
+      paginationToken = response.paginationToken();
+    } while (paginationToken != null && !paginationToken.isEmpty());
+
+    return resourceTagMappings;
+  }
+
+  private List<String> extractResourceIds(List<ResourceTagMapping> resourceTagMappings) {
+    List<String> resourceIds = new ArrayList<>();
+    for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
+      resourceIds.add(extractResourceIdFromArn(resourceTagMapping.resourceARN()));
+    }
+    return resourceIds;
+  }
+
+  private String extractResourceIdFromArn(String arn) {
+    // ARN parsing is based on
+    // https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    String[] arnArray = arn.split(":");
+    String resourceId = arnArray[arnArray.length - 1];
+    if (resourceId.contains("/")) {
+      String[] resourceArray = resourceId.split("/", 2);
+      resourceId = resourceArray[resourceArray.length - 1];
+    }
+    return resourceId;
+  }
+
+  private List<List<Dimension>> getDimensions(
+      MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
+    if (rule.awsDimensions != null
+        && rule.awsDimensionSelect != null
+        && !rule.awsDimensions.isEmpty()
+        && rule.awsDimensions.size() == rule.awsDimensionSelect.size()
+        && rule.awsDimensionSelect.keySet().containsAll(rule.awsDimensions)
+        && rule.awsTagSelect == null) {
+      // The full list of dimensions is known so no need to request it from cloudwatch.
+      return permuteDimensions(rule.awsDimensions, rule.awsDimensionSelect);
+    } else {
+      return listDimensions(rule, tagBasedResourceIds, cloudWatchClient);
+    }
+  }
+
+  private List<List<Dimension>> permuteDimensions(
+      List<String> dimensions, Map<String, List<String>> dimensionValues) {
+    ArrayList<List<Dimension>> result = new ArrayList<>();
+
+    if (dimensions.isEmpty()) {
+      result.add(new ArrayList<>());
+    } else {
+      List<String> dimensionsCopy = new ArrayList<>(dimensions);
+      String dimensionName = dimensionsCopy.remove(dimensionsCopy.size() - 1);
+      for (List<Dimension> permutation : permuteDimensions(dimensionsCopy, dimensionValues)) {
+        for (String dimensionValue : dimensionValues.get(dimensionName)) {
+          Dimension.Builder dimensionBuilder = Dimension.builder();
+          dimensionBuilder.value(dimensionValue);
+          dimensionBuilder.name(dimensionName);
+          ArrayList<Dimension> permutationCopy = new ArrayList<>(permutation);
+          permutationCopy.add(dimensionBuilder.build());
+          result.add(permutationCopy);
         }
       }
-
-      List<ResourceTagMapping> resourceTagMappings = new ArrayList<>();
-      GetResourcesRequest.Builder requestBuilder = GetResourcesRequest.builder().tagFilters(tagFilters).resourceTypeFilters(rule.awsTagSelect.resourceTypeSelection);
-      String paginationToken = "";
-      do {
-        requestBuilder.paginationToken(paginationToken);
-
-        GetResourcesResponse response = taggingClient.getResources(requestBuilder.build());
-        taggingApiRequests.labels("getResources", rule.awsTagSelect.resourceTypeSelection).inc();
-
-        resourceTagMappings.addAll(response.resourceTagMappingList());
-
-        paginationToken = response.paginationToken();
-      } while (paginationToken != null && !paginationToken.isEmpty());
-
-      return resourceTagMappings;
     }
 
-    private List<String> extractResourceIds(List<ResourceTagMapping> resourceTagMappings) {
-      List<String> resourceIds = new ArrayList<>();
-      for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
-        resourceIds.add(extractResourceIdFromArn(resourceTagMapping.resourceARN()));
-      }
-      return resourceIds;
-    }
+    return result;
+  }
 
-    private String extractResourceIdFromArn(String arn) {
-      // ARN parsing is based on https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-      String[] arnArray = arn.split(":");
-      String resourceId = arnArray[arnArray.length - 1];
-      if (resourceId.contains("/")) {
-        String[] resourceArray = resourceId.split("/", 2);
-        resourceId = resourceArray[resourceArray.length - 1];
-      }
-      return resourceId;
-    }
-
-    private List<List<Dimension>> getDimensions(MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
-        if (
-                rule.awsDimensions != null &&
-                rule.awsDimensionSelect != null &&
-                !rule.awsDimensions.isEmpty() &&
-                rule.awsDimensions.size() == rule.awsDimensionSelect.size() &&
-                rule.awsDimensionSelect.keySet().containsAll(rule.awsDimensions) &&
-                rule.awsTagSelect == null
-        ) {
-            // The full list of dimensions is known so no need to request it from cloudwatch.
-            return permuteDimensions(rule.awsDimensions, rule.awsDimensionSelect);
-        } else {
-            return listDimensions(rule, tagBasedResourceIds, cloudWatchClient);
-        }
-    }
-
-    private List<List<Dimension>> permuteDimensions(List<String> dimensions, Map<String, List<String>> dimensionValues) {
-        ArrayList<List<Dimension>> result = new ArrayList<>();
-
-        if (dimensions.isEmpty()) {
-            result.add(new ArrayList<>());
-        } else {
-            List<String> dimensionsCopy = new ArrayList<>(dimensions);
-            String dimensionName = dimensionsCopy.remove(dimensionsCopy.size() - 1);
-            for (List<Dimension> permutation : permuteDimensions(dimensionsCopy, dimensionValues)) {
-                for (String dimensionValue : dimensionValues.get(dimensionName)) {
-                    Dimension.Builder dimensionBuilder = Dimension.builder();
-                    dimensionBuilder.value(dimensionValue);
-                    dimensionBuilder.name(dimensionName);
-                    ArrayList<Dimension> permutationCopy = new ArrayList<>(permutation);
-                    permutationCopy.add(dimensionBuilder.build());
-                    result.add(permutationCopy);
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private List<List<Dimension>> listDimensions(MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
-      List<List<Dimension>> dimensions = new ArrayList<>();
-      if (rule.awsDimensions == null) {
-        dimensions.add(new ArrayList<>());
-        return dimensions;
-      }
-
-      ListMetricsRequest.Builder requestBuilder = ListMetricsRequest.builder();
-      requestBuilder.namespace(rule.awsNamespace);
-      requestBuilder.metricName(rule.awsMetricName);
-
-      // 10800 seconds is 3 hours, this setting causes metrics older than 3 hours to not be listed
-      if (rule.rangeSeconds < 10800) {
-        requestBuilder.recentlyActive("PT3H");
-      }
-
-      List<DimensionFilter> dimensionFilters = new ArrayList<>();
-      for (String dimension: rule.awsDimensions) {
-        dimensionFilters.add(DimensionFilter.builder().name(dimension).build());
-      }
-      requestBuilder.dimensions(dimensionFilters);
-
-      String nextToken = null;
-      do {
-        requestBuilder.nextToken(nextToken);
-        ListMetricsResponse response = cloudWatchClient.listMetrics(requestBuilder.build());
-        cloudwatchRequests.labels("listMetrics", rule.awsNamespace).inc();
-        for (Metric metric: response.metrics()) {
-          if (metric.dimensions().size() != dimensionFilters.size()) {
-            // AWS returns all the metrics with dimensions beyond the ones we ask for,
-            // so filter them out.
-            continue;
-          }
-          if (useMetric(rule, tagBasedResourceIds, metric)) {
-            dimensions.add(metric.dimensions());
-          }
-        }
-        nextToken = response.nextToken();
-      } while (nextToken != null);
-
+  private List<List<Dimension>> listDimensions(
+      MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
+    List<List<Dimension>> dimensions = new ArrayList<>();
+    if (rule.awsDimensions == null) {
+      dimensions.add(new ArrayList<>());
       return dimensions;
     }
 
-    /**
-     * Check if a metric should be used according to `aws_dimension_select`, `aws_dimension_select_regex` and dynamic `aws_tag_select`
-     */
-    private boolean useMetric(MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
-      if (rule.awsDimensionSelect != null && !metricsIsInAwsDimensionSelect(rule, metric)) {
-        return false;
-      }
-      if (rule.awsDimensionSelectRegex != null && !metricIsInAwsDimensionSelectRegex(rule, metric)) {
-        return false;
-      }
-      if (rule.awsTagSelect != null && !metricIsInAwsTagSelect(rule, tagBasedResourceIds, metric)) {
-        return false;
-      }
-      return true;
+    ListMetricsRequest.Builder requestBuilder = ListMetricsRequest.builder();
+    requestBuilder.namespace(rule.awsNamespace);
+    requestBuilder.metricName(rule.awsMetricName);
+
+    // 10800 seconds is 3 hours, this setting causes metrics older than 3 hours to not be listed
+    if (rule.rangeSeconds < 10800) {
+      requestBuilder.recentlyActive("PT3H");
     }
 
-    /**
-     * Check if a metric is matched in `aws_dimension_select`
-     */
-    private boolean metricsIsInAwsDimensionSelect(MetricRule rule, Metric metric) {
-      Set<String> dimensionSelectKeys = rule.awsDimensionSelect.keySet();
-      for (Dimension dimension : metric.dimensions()) {
-        String dimensionName = dimension.name();
-        String dimensionValue = dimension.value();
-        if (dimensionSelectKeys.contains(dimensionName)) {
-          List<String> allowedDimensionValues = rule.awsDimensionSelect.get(dimensionName);
-          if (!allowedDimensionValues.contains(dimensionValue)) {
-            return false;
-          }
-        }
-      }
-      return true;
+    List<DimensionFilter> dimensionFilters = new ArrayList<>();
+    for (String dimension : rule.awsDimensions) {
+      dimensionFilters.add(DimensionFilter.builder().name(dimension).build());
     }
+    requestBuilder.dimensions(dimensionFilters);
 
-    /**
-     * Check if a metric is matched in `aws_dimension_select_regex`
-     */
-    private boolean metricIsInAwsDimensionSelectRegex(MetricRule rule, Metric metric) {
-      Set<String> dimensionSelectRegexKeys = rule.awsDimensionSelectRegex.keySet();
-      for (Dimension dimension : metric.dimensions()) {
-        String dimensionName = dimension.name();
-        String dimensionValue = dimension.value();
-        if (dimensionSelectRegexKeys.contains(dimensionName)) {
-          List<String> allowedDimensionValues = rule.awsDimensionSelectRegex.get(dimensionName);
-          if (!regexListMatch(allowedDimensionValues, dimensionValue)) {
-            return false;
-          }
+    String nextToken = null;
+    do {
+      requestBuilder.nextToken(nextToken);
+      ListMetricsResponse response = cloudWatchClient.listMetrics(requestBuilder.build());
+      cloudwatchRequests.labels("listMetrics", rule.awsNamespace).inc();
+      for (Metric metric : response.metrics()) {
+        if (metric.dimensions().size() != dimensionFilters.size()) {
+          // AWS returns all the metrics with dimensions beyond the ones we ask for,
+          // so filter them out.
+          continue;
+        }
+        if (useMetric(rule, tagBasedResourceIds, metric)) {
+          dimensions.add(metric.dimensions());
         }
       }
-      return true;
-    }
+      nextToken = response.nextToken();
+    } while (nextToken != null);
 
-    /**
-     * Check if any regex string in a list matches a given input value
-     */
-    protected static boolean regexListMatch(List<String> regexList, String input) {
-      for (String regex: regexList) {
-        if (Pattern.matches(regex, input)) {
-          return true;
-        }
-      }
+    return dimensions;
+  }
+
+  /**
+   * Check if a metric should be used according to `aws_dimension_select`,
+   * `aws_dimension_select_regex` and dynamic `aws_tag_select`
+   */
+  private boolean useMetric(MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
+    if (rule.awsDimensionSelect != null && !metricsIsInAwsDimensionSelect(rule, metric)) {
       return false;
     }
+    if (rule.awsDimensionSelectRegex != null && !metricIsInAwsDimensionSelectRegex(rule, metric)) {
+      return false;
+    }
+    if (rule.awsTagSelect != null && !metricIsInAwsTagSelect(rule, tagBasedResourceIds, metric)) {
+      return false;
+    }
+    return true;
+  }
 
-    /**
-     * Check if a metric is matched in `aws_tag_select`
-     */
-    private boolean metricIsInAwsTagSelect(MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
-      if (rule.awsTagSelect.tagSelections == null) {
+  /** Check if a metric is matched in `aws_dimension_select` */
+  private boolean metricsIsInAwsDimensionSelect(MetricRule rule, Metric metric) {
+    Set<String> dimensionSelectKeys = rule.awsDimensionSelect.keySet();
+    for (Dimension dimension : metric.dimensions()) {
+      String dimensionName = dimension.name();
+      String dimensionValue = dimension.value();
+      if (dimensionSelectKeys.contains(dimensionName)) {
+        List<String> allowedDimensionValues = rule.awsDimensionSelect.get(dimensionName);
+        if (!allowedDimensionValues.contains(dimensionValue)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /** Check if a metric is matched in `aws_dimension_select_regex` */
+  private boolean metricIsInAwsDimensionSelectRegex(MetricRule rule, Metric metric) {
+    Set<String> dimensionSelectRegexKeys = rule.awsDimensionSelectRegex.keySet();
+    for (Dimension dimension : metric.dimensions()) {
+      String dimensionName = dimension.name();
+      String dimensionValue = dimension.value();
+      if (dimensionSelectRegexKeys.contains(dimensionName)) {
+        List<String> allowedDimensionValues = rule.awsDimensionSelectRegex.get(dimensionName);
+        if (!regexListMatch(allowedDimensionValues, dimensionValue)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /** Check if any regex string in a list matches a given input value */
+  protected static boolean regexListMatch(List<String> regexList, String input) {
+    for (String regex : regexList) {
+      if (Pattern.matches(regex, input)) {
         return true;
       }
-      for (Dimension dimension : metric.dimensions()) {
-        String dimensionName = dimension.name();
-        String dimensionValue = dimension.value();
-        if (rule.awsTagSelect.resourceIdDimension.equals(dimensionName) && !tagBasedResourceIds.contains(dimensionValue)) {
-            return false;
-        }
-      }
+    }
+    return false;
+  }
+
+  /** Check if a metric is matched in `aws_tag_select` */
+  private boolean metricIsInAwsTagSelect(
+      MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
+    if (rule.awsTagSelect.tagSelections == null) {
       return true;
     }
-
-    private String toSnakeCase(String str) {
-      return str.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toLowerCase();
-    }
-
-    private String safeName(String s) {
-      // Change invalid chars to underscore, and merge underscores.
-      return s.replaceAll("[^a-zA-Z0-9:_]", "_").replaceAll("__+", "_");
-    }
-
-    private String safeLabelName(String s) {
-      // Change invalid chars to underscore, and merge underscores.
-      return s.replaceAll("[^a-zA-Z0-9_]", "_").replaceAll("__+", "_");
-    }
-
-    private String help(MetricRule rule, String unit, String statistic) {
-      if (rule.help != null) {
-          return rule.help;
-      }
-      return "CloudWatch metric " + rule.awsNamespace + " " + rule.awsMetricName
-          + " Dimensions: " + rule.awsDimensions + " Statistic: " + statistic
-          + " Unit: " + unit;
-    }
-
-    private String sampleLabelSuffixBy(Statistic s) {
-      switch (s) {
-        case SUM:
-          return "_sum";
-        case SAMPLE_COUNT:
-          return "_sample_count";
-        case MINIMUM:
-          return "_minimum";
-        case MAXIMUM:
-          return "_maximum";
-        case AVERAGE:
-          return "_average";
-        default:
-          throw new RuntimeException("I did not expect this stats!");
+    for (Dimension dimension : metric.dimensions()) {
+      String dimensionName = dimension.name();
+      String dimensionValue = dimension.value();
+      if (rule.awsTagSelect.resourceIdDimension.equals(dimensionName)
+          && !tagBasedResourceIds.contains(dimensionValue)) {
+        return false;
       }
     }
+    return true;
+  }
 
-    private void scrape(List<MetricFamilySamples> mfs) {
-      ActiveConfig config = new ActiveConfig(activeConfig);
-      Set<String> publishedResourceInfo = new HashSet<>();
+  private String toSnakeCase(String str) {
+    return str.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toLowerCase();
+  }
 
-      long start = System.currentTimeMillis();
-      List<MetricFamilySamples.Sample> infoSamples = new ArrayList<>();
+  private String safeName(String s) {
+    // Change invalid chars to underscore, and merge underscores.
+    return s.replaceAll("[^a-zA-Z0-9:_]", "_").replaceAll("__+", "_");
+  }
 
-      for (MetricRule rule: config.rules) {
-        String baseName = safeName(rule.awsNamespace.toLowerCase() + "_" + toSnakeCase(rule.awsMetricName));
-        String jobName = safeName(rule.awsNamespace.toLowerCase());
-        Map<Statistic, List<MetricFamilySamples.Sample>> baseSamples = new HashMap<>();
-        for (Statistic s : Statistic.values()) {
-          baseSamples.put(s, new ArrayList<>());
+  private String safeLabelName(String s) {
+    // Change invalid chars to underscore, and merge underscores.
+    return s.replaceAll("[^a-zA-Z0-9_]", "_").replaceAll("__+", "_");
+  }
+
+  private String help(MetricRule rule, String unit, String statistic) {
+    if (rule.help != null) {
+      return rule.help;
+    }
+    return "CloudWatch metric "
+        + rule.awsNamespace
+        + " "
+        + rule.awsMetricName
+        + " Dimensions: "
+        + rule.awsDimensions
+        + " Statistic: "
+        + statistic
+        + " Unit: "
+        + unit;
+  }
+
+  private String sampleLabelSuffixBy(Statistic s) {
+    switch (s) {
+      case SUM:
+        return "_sum";
+      case SAMPLE_COUNT:
+        return "_sample_count";
+      case MINIMUM:
+        return "_minimum";
+      case MAXIMUM:
+        return "_maximum";
+      case AVERAGE:
+        return "_average";
+      default:
+        throw new RuntimeException("I did not expect this stats!");
+    }
+  }
+
+  private void scrape(List<MetricFamilySamples> mfs) {
+    ActiveConfig config = new ActiveConfig(activeConfig);
+    Set<String> publishedResourceInfo = new HashSet<>();
+
+    long start = System.currentTimeMillis();
+    List<MetricFamilySamples.Sample> infoSamples = new ArrayList<>();
+
+    for (MetricRule rule : config.rules) {
+      String baseName =
+          safeName(rule.awsNamespace.toLowerCase() + "_" + toSnakeCase(rule.awsMetricName));
+      String jobName = safeName(rule.awsNamespace.toLowerCase());
+      Map<Statistic, List<MetricFamilySamples.Sample>> baseSamples = new HashMap<>();
+      for (Statistic s : Statistic.values()) {
+        baseSamples.put(s, new ArrayList<>());
+      }
+      HashMap<String, List<MetricFamilySamples.Sample>> extendedSamples = new HashMap<>();
+
+      String unit = null;
+
+      if (rule.awsNamespace.equals("AWS/DynamoDB")
+          && rule.awsDimensions != null
+          && rule.awsDimensions.contains("GlobalSecondaryIndexName")
+          && brokenDynamoMetrics.contains(rule.awsMetricName)) {
+        baseName += "_index";
+      }
+
+      List<ResourceTagMapping> resourceTagMappings =
+          getResourceTagMappings(rule, config.taggingClient);
+      List<String> tagBasedResourceIds = extractResourceIds(resourceTagMappings);
+
+      List<List<Dimension>> dimentionsList =
+          getDimensions(rule, tagBasedResourceIds, config.cloudWatchClient);
+      DataGetter dataGetter = null;
+      if (rule.useGetMetricData) {
+        dataGetter =
+            new GetMetricDataDataGetter(
+                config.cloudWatchClient,
+                start,
+                rule,
+                cloudwatchRequests,
+                cloudwatchMetricsRequsted,
+                dimentionsList);
+      } else {
+        dataGetter =
+            new GetMetricStatisticsDataGetter(
+                config.cloudWatchClient,
+                start,
+                rule,
+                cloudwatchRequests,
+                cloudwatchMetricsRequsted);
+      }
+
+      for (List<Dimension> dimensions : dimentionsList) {
+        MetricRuleData values = dataGetter.metricRuleDataFor(dimensions);
+        if (values == null) {
+          continue;
         }
-        HashMap<String, List<MetricFamilySamples.Sample>> extendedSamples = new HashMap<>();
 
-        String unit = null;
-
-        if (rule.awsNamespace.equals("AWS/DynamoDB")
-                && rule.awsDimensions != null
-                && rule.awsDimensions.contains("GlobalSecondaryIndexName")
-                && brokenDynamoMetrics.contains(rule.awsMetricName)) {
-            baseName += "_index";
+        List<String> labelNames = new ArrayList<>();
+        List<String> labelValues = new ArrayList<>();
+        labelNames.add("job");
+        labelValues.add(jobName);
+        labelNames.add("instance");
+        labelValues.add("");
+        for (Dimension d : dimensions) {
+          labelNames.add(safeLabelName(toSnakeCase(d.name())));
+          labelValues.add(d.value());
         }
 
-        List<ResourceTagMapping> resourceTagMappings = getResourceTagMappings(rule, config.taggingClient);
-        List<String> tagBasedResourceIds = extractResourceIds(resourceTagMappings);
-
-        List<List<Dimension>> dimentionsList = getDimensions(rule, tagBasedResourceIds, config.cloudWatchClient);
-        DataGetter dataGetter = null;
-        if (rule.useGetMetricData) {
-          dataGetter = new GetMetricDataDataGetter(config.cloudWatchClient, start, rule, cloudwatchRequests,cloudwatchMetricsRequsted,
-                    dimentionsList);
-        } else {
-          dataGetter = new GetMetricStatisticsDataGetter(config.cloudWatchClient, start, rule, cloudwatchRequests, cloudwatchMetricsRequsted);
+        Long timestamp = null;
+        if (rule.cloudwatchTimestamp) {
+          timestamp = values.timestamp.toEpochMilli();
         }
-        
-        for (List<Dimension> dimensions : dimentionsList) {
-          MetricRuleData values = dataGetter.metricRuleDataFor(dimensions);
-          if (values == null) {
-            continue;
-          }
 
+        // iterate over aws statistics
+        for (Entry<Statistic, Double> e : values.statisticValues.entrySet()) {
+          String suffix = sampleLabelSuffixBy(e.getKey());
+          baseSamples
+              .get(e.getKey())
+              .add(
+                  new MetricFamilySamples.Sample(
+                      baseName + suffix, labelNames, labelValues, e.getValue(), timestamp));
+        }
+
+        // iterate over extended values
+        for (Entry<String, Double> entry : values.extendedValues.entrySet()) {
+          List<MetricFamilySamples.Sample> samples =
+              extendedSamples.getOrDefault(entry.getKey(), new ArrayList<>());
+          samples.add(
+              new MetricFamilySamples.Sample(
+                  baseName + "_" + safeName(toSnakeCase(entry.getKey())),
+                  labelNames,
+                  labelValues,
+                  entry.getValue(),
+                  timestamp));
+          extendedSamples.put(entry.getKey(), samples);
+        }
+      }
+
+      if (!baseSamples.get(Statistic.SUM).isEmpty()) {
+        mfs.add(
+            new MetricFamilySamples(
+                baseName + "_sum",
+                Type.GAUGE,
+                help(rule, unit, "Sum"),
+                baseSamples.get(Statistic.SUM)));
+      }
+      if (!baseSamples.get(Statistic.SAMPLE_COUNT).isEmpty()) {
+        mfs.add(
+            new MetricFamilySamples(
+                baseName + "_sample_count",
+                Type.GAUGE,
+                help(rule, unit, "SampleCount"),
+                baseSamples.get(Statistic.SAMPLE_COUNT)));
+      }
+      if (!baseSamples.get(Statistic.MINIMUM).isEmpty()) {
+        mfs.add(
+            new MetricFamilySamples(
+                baseName + "_minimum",
+                Type.GAUGE,
+                help(rule, unit, "Minimum"),
+                baseSamples.get(Statistic.MINIMUM)));
+      }
+      if (!baseSamples.get(Statistic.MAXIMUM).isEmpty()) {
+        mfs.add(
+            new MetricFamilySamples(
+                baseName + "_maximum",
+                Type.GAUGE,
+                help(rule, unit, "Maximum"),
+                baseSamples.get(Statistic.MAXIMUM)));
+      }
+      if (!baseSamples.get(Statistic.AVERAGE).isEmpty()) {
+        mfs.add(
+            new MetricFamilySamples(
+                baseName + "_average",
+                Type.GAUGE,
+                help(rule, unit, "Average"),
+                baseSamples.get(Statistic.AVERAGE)));
+      }
+      for (Map.Entry<String, List<MetricFamilySamples.Sample>> entry : extendedSamples.entrySet()) {
+        mfs.add(
+            new MetricFamilySamples(
+                baseName + "_" + safeName(toSnakeCase(entry.getKey())),
+                Type.GAUGE,
+                help(rule, unit, entry.getKey()),
+                entry.getValue()));
+      }
+
+      // Add the "aws_resource_info" metric for existing tag mappings
+      for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
+        if (!publishedResourceInfo.contains(resourceTagMapping.resourceARN())) {
           List<String> labelNames = new ArrayList<>();
           List<String> labelValues = new ArrayList<>();
           labelNames.add("job");
           labelValues.add(jobName);
           labelNames.add("instance");
           labelValues.add("");
-          for (Dimension d: dimensions) {
-            labelNames.add(safeLabelName(toSnakeCase(d.name())));
-            labelValues.add(d.value());
+          labelNames.add("arn");
+          labelValues.add(resourceTagMapping.resourceARN());
+          labelNames.add(safeLabelName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
+          labelValues.add(extractResourceIdFromArn(resourceTagMapping.resourceARN()));
+          for (Tag tag : resourceTagMapping.tags()) {
+            // Avoid potential collision between resource tags and other metric labels by adding the
+            // "tag_" prefix
+            // The AWS tags are case sensitive, so to avoid loosing information and label
+            // collisions, tag keys are not snaked cased
+            labelNames.add("tag_" + safeLabelName(tag.key()));
+            labelValues.add(tag.value());
           }
 
-          Long timestamp = null;
-          if (rule.cloudwatchTimestamp) {
-            timestamp = values.timestamp.toEpochMilli();
-          }
+          infoSamples.add(
+              new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
 
-          // iterate over aws statistics
-          for (Entry<Statistic, Double> e : values.statisticValues.entrySet()) {
-            String suffix = sampleLabelSuffixBy(e.getKey());
-            baseSamples.get(e.getKey()).add(new MetricFamilySamples.Sample(
-                      baseName + suffix, labelNames, labelValues, e.getValue(), timestamp));
-          }
-
-          // iterate over extended values
-          for (Entry<String, Double> entry : values.extendedValues.entrySet()) {
-            List<MetricFamilySamples.Sample> samples = extendedSamples.getOrDefault(entry.getKey(), new ArrayList<>());
-            samples.add(new MetricFamilySamples.Sample(
-                    baseName + "_" + safeName(toSnakeCase(entry.getKey())), labelNames, labelValues, entry.getValue(),
-                    timestamp));
-            extendedSamples.put(entry.getKey(), samples);
-          }
+          publishedResourceInfo.add(resourceTagMapping.resourceARN());
         }
-
-        if (!baseSamples.get(Statistic.SUM).isEmpty()) {
-          mfs.add(new MetricFamilySamples(baseName + "_sum", Type.GAUGE, help(rule, unit, "Sum"),
-                  baseSamples.get(Statistic.SUM)));
-        }
-        if (!baseSamples.get(Statistic.SAMPLE_COUNT).isEmpty()) {
-          mfs.add(new MetricFamilySamples(baseName + "_sample_count", Type.GAUGE, help(rule, unit, "SampleCount"),
-                  baseSamples.get(Statistic.SAMPLE_COUNT)));
-        }
-        if (!baseSamples.get(Statistic.MINIMUM).isEmpty()) {
-          mfs.add(new MetricFamilySamples(baseName + "_minimum", Type.GAUGE, help(rule, unit, "Minimum"),
-                  baseSamples.get(Statistic.MINIMUM)));
-        }
-        if (!baseSamples.get(Statistic.MAXIMUM).isEmpty()) {
-          mfs.add(new MetricFamilySamples(baseName + "_maximum", Type.GAUGE, help(rule, unit, "Maximum"),
-                  baseSamples.get(Statistic.MAXIMUM)));
-        }
-        if (!baseSamples.get(Statistic.AVERAGE).isEmpty()) {
-          mfs.add(new MetricFamilySamples(baseName + "_average", Type.GAUGE, help(rule, unit, "Average"),
-                  baseSamples.get(Statistic.AVERAGE)));
-        }
-        for (Map.Entry<String, List<MetricFamilySamples.Sample>> entry : extendedSamples.entrySet()) {
-          mfs.add(new MetricFamilySamples(baseName + "_" + safeName(toSnakeCase(entry.getKey())), Type.GAUGE,
-                  help(rule, unit, entry.getKey()), entry.getValue()));
-        }
-
-        // Add the "aws_resource_info" metric for existing tag mappings
-        for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
-          if (!publishedResourceInfo.contains(resourceTagMapping.resourceARN())) {
-            List<String> labelNames = new ArrayList<>();
-            List<String> labelValues = new ArrayList<>();
-            labelNames.add("job");
-            labelValues.add(jobName);
-            labelNames.add("instance");
-            labelValues.add("");
-            labelNames.add("arn");
-            labelValues.add(resourceTagMapping.resourceARN());
-            labelNames.add(safeLabelName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
-            labelValues.add(extractResourceIdFromArn(resourceTagMapping.resourceARN()));
-            for (Tag tag: resourceTagMapping.tags()) {
-              // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
-              // The AWS tags are case sensitive, so to avoid loosing information and label collisions, tag keys are not snaked cased
-              labelNames.add("tag_" + safeLabelName(tag.key()));
-              labelValues.add(tag.value());
-            }
-
-            infoSamples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
-
-            publishedResourceInfo.add(resourceTagMapping.resourceARN());
-          }
-        }
-      }
-      mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", infoSamples));
-    }
-
-    public List<MetricFamilySamples> collect() {
-      long start = System.nanoTime();
-      double error = 0;
-      List<MetricFamilySamples> mfs = new ArrayList<>();
-      try {
-        scrape(mfs);
-      } catch (Exception e) {
-        error = 1;
-        LOGGER.log(Level.WARNING, "CloudWatch scrape failed", e);
-      }
-      List<MetricFamilySamples.Sample> samples = new ArrayList<>();
-      samples.add(new MetricFamilySamples.Sample(
-          "cloudwatch_exporter_scrape_duration_seconds", new ArrayList<>(), new ArrayList<>(), (System.nanoTime() - start) / 1.0E9));
-      mfs.add(new MetricFamilySamples("cloudwatch_exporter_scrape_duration_seconds", Type.GAUGE, "Time this CloudWatch scrape took, in seconds.", samples));
-
-      samples = new ArrayList<>();
-      samples.add(new MetricFamilySamples.Sample(
-          "cloudwatch_exporter_scrape_error", new ArrayList<>(), new ArrayList<>(), error));
-      mfs.add(new MetricFamilySamples("cloudwatch_exporter_scrape_error", Type.GAUGE, "Non-zero if this scrape failed.", samples));
-      return mfs;
-    }
-
-    /**
-     * Convenience function to run standalone.
-     */
-    public static void main(String[] args) {
-      String region = "eu-west-1";
-      if (args.length > 0) {
-        region = args[0];
-      }
-      new BuildInfoCollector().register();
-      CloudWatchCollector jc = new CloudWatchCollector(("{"
-      + "`region`: `" + region + "`,"
-      + "`metrics`: [{`aws_namespace`: `AWS/ELB`, `aws_metric_name`: `RequestCount`, `aws_dimensions`: [`AvailabilityZone`, `LoadBalancerName`]}] ,"
-      + "}").replace('`', '"'));
-      for(MetricFamilySamples mfs : jc.collect()) {
-        System.out.println(mfs);
       }
     }
+    mfs.add(
+        new MetricFamilySamples(
+            "aws_resource_info",
+            Type.GAUGE,
+            "AWS information available for resource",
+            infoSamples));
+  }
+
+  public List<MetricFamilySamples> collect() {
+    long start = System.nanoTime();
+    double error = 0;
+    List<MetricFamilySamples> mfs = new ArrayList<>();
+    try {
+      scrape(mfs);
+    } catch (Exception e) {
+      error = 1;
+      LOGGER.log(Level.WARNING, "CloudWatch scrape failed", e);
+    }
+    List<MetricFamilySamples.Sample> samples = new ArrayList<>();
+    samples.add(
+        new MetricFamilySamples.Sample(
+            "cloudwatch_exporter_scrape_duration_seconds",
+            new ArrayList<>(),
+            new ArrayList<>(),
+            (System.nanoTime() - start) / 1.0E9));
+    mfs.add(
+        new MetricFamilySamples(
+            "cloudwatch_exporter_scrape_duration_seconds",
+            Type.GAUGE,
+            "Time this CloudWatch scrape took, in seconds.",
+            samples));
+
+    samples = new ArrayList<>();
+    samples.add(
+        new MetricFamilySamples.Sample(
+            "cloudwatch_exporter_scrape_error", new ArrayList<>(), new ArrayList<>(), error));
+    mfs.add(
+        new MetricFamilySamples(
+            "cloudwatch_exporter_scrape_error",
+            Type.GAUGE,
+            "Non-zero if this scrape failed.",
+            samples));
+    return mfs;
+  }
+
+  /** Convenience function to run standalone. */
+  public static void main(String[] args) {
+    String region = "eu-west-1";
+    if (args.length > 0) {
+      region = args[0];
+    }
+    new BuildInfoCollector().register();
+    CloudWatchCollector jc =
+        new CloudWatchCollector(
+            ("{"
+                    + "`region`: `"
+                    + region
+                    + "`,"
+                    + "`metrics`: [{`aws_namespace`: `AWS/ELB`, `aws_metric_name`: `RequestCount`, `aws_dimensions`: [`AvailabilityZone`, `LoadBalancerName`]}] ,"
+                    + "}")
+                .replace('`', '"'));
+    for (MetricFamilySamples mfs : jc.collect()) {
+      System.out.println(mfs);
+    }
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/DataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/DataGetter.java
@@ -4,22 +4,21 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.Statistic;
 
 interface DataGetter {
-    MetricRuleData metricRuleDataFor(List<Dimension> dimensions);
+  MetricRuleData metricRuleDataFor(List<Dimension> dimensions);
 
-    class MetricRuleData {
-        Map<Statistic, Double> statisticValues;
-        Map<String, Double> extendedValues;
-        Instant timestamp;
+  class MetricRuleData {
+    Map<Statistic, Double> statisticValues;
+    Map<String, Double> extendedValues;
+    Instant timestamp;
 
-        MetricRuleData(Instant timestamp) {
-            this.timestamp = timestamp;
-            this.statisticValues = new HashMap<>();
-            this.extendedValues = new HashMap<>();
-        }
+    MetricRuleData(Instant timestamp) {
+      this.timestamp = timestamp;
+      this.statisticValues = new HashMap<>();
+      this.extendedValues = new HashMap<>();
     }
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -1,52 +1,54 @@
 package io.prometheus.cloudwatch;
 
+import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 public class DynamicReloadServlet extends HttpServlet {
-    private static final long serialVersionUID = 9078784531819993933L;
-    private final CloudWatchCollector collector;
+  private static final long serialVersionUID = 9078784531819993933L;
+  private final CloudWatchCollector collector;
 
-    public DynamicReloadServlet(CloudWatchCollector collector) {
-        this.collector = collector;
+  public DynamicReloadServlet(CloudWatchCollector collector) {
+    this.collector = collector;
+  }
+
+  static final String CONTENT_TYPE = "text/plain";
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    resp.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    resp.setContentType(CONTENT_TYPE);
+    try {
+      resp.getWriter().print("Only POST requests allowed");
+    } catch (IOException e) {
+      // Ignored
+    }
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    try {
+      collector.reloadConfig();
+    } catch (IOException e) {
+      resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      resp.setContentType(CONTENT_TYPE);
+      try {
+        resp.getWriter().print("Reloading config failed");
+      } catch (IOException ee) {
+        // Ignored
+      }
+      return;
     }
 
-    static final String CONTENT_TYPE = "text/plain";
-
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
-        resp.setContentType(CONTENT_TYPE);
-        try {
-            resp.getWriter().print("Only POST requests allowed");
-        } catch (IOException e) {
-            // Ignored
-        }
+    resp.setContentType(CONTENT_TYPE);
+    try {
+      resp.getWriter().print("OK");
+    } catch (IOException e) {
+      // Ignored
     }
-
-    @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        try {
-            collector.reloadConfig();
-        } catch (IOException e) {
-            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            resp.setContentType(CONTENT_TYPE);
-            try {
-                resp.getWriter().print("Reloading config failed");
-            } catch (IOException ee) {
-                // Ignored
-            }
-            return;
-        }
-
-        resp.setContentType(CONTENT_TYPE);
-        try {
-            resp.getWriter().print("OK");
-        } catch (IOException e) {
-            // Ignored
-        }
-    }
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
@@ -1,5 +1,7 @@
 package io.prometheus.cloudwatch;
 
+import io.prometheus.client.Counter;
+import io.prometheus.cloudwatch.CloudWatchCollector.MetricRule;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -7,9 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.logging.Logger;
-
-import io.prometheus.cloudwatch.CloudWatchCollector.MetricRule;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
 import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataResponse;
@@ -19,203 +19,203 @@ import software.amazon.awssdk.services.cloudwatch.model.MetricDataResult;
 import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 import software.amazon.awssdk.services.cloudwatch.model.ScanBy;
 import software.amazon.awssdk.services.cloudwatch.model.Statistic;
-import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
-import io.prometheus.client.Counter;
 
 class GetMetricDataDataGetter implements DataGetter {
 
-    private final static int MAX_QUERIES_PER_REQUEST = 500;
-    // https://aws.amazon.com/cloudwatch/pricing/
-    private final static int MAX_STATS_PER_BILLED_METRIC_REQUEST = 5;
-    private long start;
-    private MetricRule rule;
-    private CloudWatchClient client;
-    private Counter apiRequestsCounter;
-    private Counter metricsRequestedCounter;
-    private Map<String, MetricRuleData> results;
-    private Double metricRequestedForBilling;
+  private static final int MAX_QUERIES_PER_REQUEST = 500;
+  // https://aws.amazon.com/cloudwatch/pricing/
+  private static final int MAX_STATS_PER_BILLED_METRIC_REQUEST = 5;
+  private long start;
+  private MetricRule rule;
+  private CloudWatchClient client;
+  private Counter apiRequestsCounter;
+  private Counter metricsRequestedCounter;
+  private Map<String, MetricRuleData> results;
+  private Double metricRequestedForBilling;
 
-    private static String dimentionToString(Dimension d) {
-        return String.format("%s=%s", d.name(), d.value());
+  private static String dimentionToString(Dimension d) {
+    return String.format("%s=%s", d.name(), d.value());
+  }
+
+  private static String dimentionsToKey(List<Dimension> dimentions) {
+    return String.join(",", dimentions.stream().map(d -> dimentionToString(d)).sorted().toList());
+  }
+
+  private List<String> buildStatsList(MetricRule rule) {
+    List<String> stats = new ArrayList<>();
+    if (rule.awsStatistics != null) {
+      stats.addAll(rule.awsStatistics.stream().map(s -> s.toString()).toList());
+    }
+    if (rule.awsExtendedStatistics != null) {
+      stats.addAll(rule.awsExtendedStatistics);
+    }
+    return stats;
+  }
+
+  private List<MetricDataQuery> buildMetricDataQueries(
+      MetricRule rule, List<List<Dimension>> dimentionsList) {
+    List<MetricDataQuery> queries = new ArrayList<>();
+    List<String> stats = buildStatsList(rule);
+    for (String stat : stats) {
+      for (List<Dimension> dl : dimentionsList) {
+        Metric metric = buildMetric(rule, dl);
+        MetricStat metricStat = buildMetricStat(rule, stat, metric);
+        MetricDataQuery query = buildQuery(stat, dl, metricStat);
+        queries.add(query);
+      }
+    }
+    Double metricRequested = Math.ceil((double) stats.size() / MAX_STATS_PER_BILLED_METRIC_REQUEST);
+    metricRequestedForBilling += metricRequested;
+    return queries;
+  }
+
+  private MetricDataQuery buildQuery(String stat, List<Dimension> dl, MetricStat metric) {
+    // random id - we don't care about it
+    String id = "i" + UUID.randomUUID().toString().replace("-", "");
+    MetricDataQuery.Builder builder = MetricDataQuery.builder();
+    builder.id(id);
+
+    // important - used to locate back the results
+    String label = MetricLabels.labelFor(stat, dl);
+    builder.label(label);
+    builder.metricStat(metric);
+    return builder.build();
+  }
+
+  private MetricStat buildMetricStat(MetricRule rule2, String stat, Metric metric) {
+    MetricStat.Builder builder = MetricStat.builder();
+    builder.period(rule.periodSeconds);
+    builder.stat(stat);
+    builder.metric(metric);
+    return builder.build();
+  }
+
+  private Metric buildMetric(MetricRule rule2, List<Dimension> dl) {
+    Metric.Builder builder = Metric.builder();
+    builder.namespace(rule.awsNamespace);
+    builder.metricName(rule.awsMetricName);
+    builder.dimensions(dl);
+    return builder.build();
+  }
+
+  public static <T> List<List<T>> partitionByMaxSize(List<T> list, int maxPartitionSize) {
+    List<List<T>> partitions = new ArrayList<>();
+    List<T> remaining = list;
+    while (remaining.size() > 0) {
+      if (remaining.size() < maxPartitionSize) {
+        partitions.add(remaining);
+        break;
+      } else {
+        partitions.add(remaining.subList(0, maxPartitionSize));
+        remaining = remaining.subList(maxPartitionSize, remaining.size());
+      }
+    }
+    return partitions;
+  }
+
+  private List<GetMetricDataRequest> buildMetricDataRequests(
+      MetricRule rule, List<List<Dimension>> dimentionsList) {
+    Date startDate = new Date(start - 1000 * rule.delaySeconds);
+    Date endDate = new Date(start - 1000 * (rule.delaySeconds + rule.rangeSeconds));
+    GetMetricDataRequest.Builder builder = GetMetricDataRequest.builder();
+    builder.endTime(startDate.toInstant());
+    builder.startTime(endDate.toInstant());
+    builder.scanBy(ScanBy.TIMESTAMP_DESCENDING);
+    List<MetricDataQuery> queries = buildMetricDataQueries(rule, dimentionsList);
+    List<GetMetricDataRequest> requests = new ArrayList<>();
+    for (List<MetricDataQuery> queriesPartition :
+        partitionByMaxSize(queries, MAX_QUERIES_PER_REQUEST)) {
+      requests.add(builder.metricDataQueries(queriesPartition).build());
+    }
+    return requests;
+  }
+
+  private Map<String, MetricRuleData> fetchAllDataPoints(List<List<Dimension>> dimentionsList) {
+    List<MetricDataResult> results = new ArrayList<>();
+    for (GetMetricDataRequest request : buildMetricDataRequests(rule, dimentionsList)) {
+      GetMetricDataResponse response = client.getMetricData(request);
+      apiRequestsCounter.labels("getMetricData", rule.awsNamespace).inc();
+      results.addAll(response.metricDataResults());
+    }
+    metricsRequestedCounter
+        .labels(rule.awsMetricName, rule.awsNamespace)
+        .inc(metricRequestedForBilling);
+    return toMap(results);
+  }
+
+  private Map<String, MetricRuleData> toMap(List<MetricDataResult> metricDataResults) {
+    Map<String, MetricRuleData> res = new HashMap<>();
+    for (MetricDataResult dataResult : metricDataResults) {
+      if (dataResult.timestamps().isEmpty() || dataResult.values().isEmpty()) {
+        continue;
+      }
+      StatAndDimentions statAndDimentions = MetricLabels.decode(dataResult.label());
+      String statString = statAndDimentions.stat;
+      String labelsKey = statAndDimentions.dimetionsAsString;
+      Instant timestamp = dataResult.timestamps().get(0);
+      Double value = dataResult.values().get(0);
+      MetricRuleData metricRuleData = res.getOrDefault(labelsKey, new MetricRuleData(timestamp));
+      Statistic stat = Statistic.fromValue(statString);
+      if (stat == Statistic.UNKNOWN_TO_SDK_VERSION) {
+        metricRuleData.extendedValues.put(statString, value);
+      } else {
+        metricRuleData.statisticValues.put(stat, value);
+      }
+      res.put(labelsKey, metricRuleData);
+    }
+    return res;
+  }
+
+  GetMetricDataDataGetter(
+      CloudWatchClient client,
+      long start,
+      MetricRule rule,
+      Counter apiRequestsCounter,
+      Counter metricsRequestedCounter,
+      List<List<Dimension>> dimentionsList) {
+    this.client = client;
+    this.start = start;
+    this.rule = rule;
+    this.apiRequestsCounter = apiRequestsCounter;
+    this.metricsRequestedCounter = metricsRequestedCounter;
+    this.metricRequestedForBilling = 0d;
+    this.results = fetchAllDataPoints(dimentionsList);
+  }
+
+  @Override
+  public MetricRuleData metricRuleDataFor(List<Dimension> dimensions) {
+    return results.get(dimentionsToKey(dimensions));
+  }
+
+  private static class StatAndDimentions {
+    String dimetionsAsString;
+    String stat;
+
+    StatAndDimentions(String stat, String dimetionsAsString) {
+      this.stat = stat;
+      this.dimetionsAsString = dimetionsAsString;
+    }
+  }
+
+  static class MetricLabels {
+    static String labelFor(String stat, List<Dimension> dimensions) {
+      return String.format("%s/%s", stat, dimentionsToKey(dimensions));
     }
 
-    private static String dimentionsToKey(List<Dimension> dimentions) {
-        return String.join(",",
-                dimentions.stream().map(d -> dimentionToString(d)).sorted().toList());
+    static StatAndDimentions decode(String label) {
+      String[] labelParts = label.split("/", 2);
+      if (labelParts.length != 2) {
+        throw new UnexpectedLabel(label);
+      }
+      String statString = labelParts[0];
+      String labelsKey = labelParts[1];
+      return new StatAndDimentions(statString, labelsKey);
     }
 
-    private List<String> buildStatsList(MetricRule rule) {
-        List<String> stats = new ArrayList<>();
-        if (rule.awsStatistics != null) {
-            stats.addAll(rule.awsStatistics.stream().map(s -> s.toString()).toList());
-        }
-        if (rule.awsExtendedStatistics != null) {
-            stats.addAll(rule.awsExtendedStatistics);
-        }
-        return stats;
+    static class UnexpectedLabel extends RuntimeException {
+      public UnexpectedLabel(String label) {
+        super(String.format("Cannot decode label %s", label));
+      }
     }
-
-    private List<MetricDataQuery> buildMetricDataQueries(MetricRule rule,
-            List<List<Dimension>> dimentionsList) {
-        List<MetricDataQuery> queries = new ArrayList<>();
-        List<String> stats = buildStatsList(rule);
-        for (String stat : stats) {
-            for (List<Dimension> dl : dimentionsList) {
-                Metric metric = buildMetric(rule, dl);
-                MetricStat metricStat = buildMetricStat(rule, stat, metric);
-                MetricDataQuery query = buildQuery(stat, dl, metricStat);
-                queries.add(query);
-            }
-        }
-        Double metricRequested = Math.ceil((double) stats.size() / MAX_STATS_PER_BILLED_METRIC_REQUEST);
-        metricRequestedForBilling += metricRequested;
-        return queries;
-    }
-
-    private MetricDataQuery buildQuery(String stat, List<Dimension> dl, MetricStat metric) {
-        // random id - we don't care about it
-        String id = "i" + UUID.randomUUID().toString().replace("-", "");
-        MetricDataQuery.Builder builder = MetricDataQuery.builder();
-        builder.id(id);
-
-        // important - used to locate back the results
-        String label = MetricLabels.labelFor(stat, dl);
-        builder.label(label);
-        builder.metricStat(metric);
-        return builder.build();
-    }
-
-    private MetricStat buildMetricStat(MetricRule rule2, String stat, Metric metric) {
-        MetricStat.Builder builder = MetricStat.builder();
-        builder.period(rule.periodSeconds);
-        builder.stat(stat);
-        builder.metric(metric);
-        return builder.build();
-    }
-
-    private Metric buildMetric(MetricRule rule2, List<Dimension> dl) {
-        Metric.Builder builder = Metric.builder();
-        builder.namespace(rule.awsNamespace);
-        builder.metricName(rule.awsMetricName);
-        builder.dimensions(dl);
-        return builder.build();
-    }
-
-    public static <T> List<List<T>> partitionByMaxSize(List<T> list, int maxPartitionSize) {
-        List<List<T>> partitions = new ArrayList<>();
-        List<T> remaining = list;
-        while (remaining.size() > 0) {
-            if (remaining.size() < maxPartitionSize) {
-                partitions.add(remaining);
-                break;
-            } else {
-                partitions.add(remaining.subList(0, maxPartitionSize));
-                remaining = remaining.subList(maxPartitionSize, remaining.size());
-            }
-        }
-        return partitions;
-    }
-
-    private List<GetMetricDataRequest> buildMetricDataRequests(MetricRule rule,
-            List<List<Dimension>> dimentionsList) {
-        Date startDate = new Date(start - 1000 * rule.delaySeconds);
-        Date endDate = new Date(start - 1000 * (rule.delaySeconds + rule.rangeSeconds));
-        GetMetricDataRequest.Builder builder = GetMetricDataRequest.builder();
-        builder.endTime(startDate.toInstant());
-        builder.startTime(endDate.toInstant());
-        builder.scanBy(ScanBy.TIMESTAMP_DESCENDING);
-        List<MetricDataQuery> queries = buildMetricDataQueries(rule, dimentionsList);
-        List<GetMetricDataRequest> requests = new ArrayList<>();
-        for (List<MetricDataQuery> queriesPartition : partitionByMaxSize(queries,
-                MAX_QUERIES_PER_REQUEST)) {
-            requests.add(builder.metricDataQueries(queriesPartition).build());
-        }
-        return requests;
-    }
-
-    private Map<String, MetricRuleData> fetchAllDataPoints(List<List<Dimension>> dimentionsList) {
-        List<MetricDataResult> results = new ArrayList<>();
-        for (GetMetricDataRequest request : buildMetricDataRequests(rule, dimentionsList)) {
-            GetMetricDataResponse response = client.getMetricData(request);
-            apiRequestsCounter.labels("getMetricData", rule.awsNamespace).inc();
-            results.addAll(response.metricDataResults());
-        }
-        metricsRequestedCounter.labels(rule.awsMetricName, rule.awsNamespace)
-                .inc(metricRequestedForBilling);
-        return toMap(results);
-    }
-
-    private Map<String, MetricRuleData> toMap(List<MetricDataResult> metricDataResults) {
-        Map<String, MetricRuleData> res = new HashMap<>();
-        for (MetricDataResult dataResult : metricDataResults) {
-            if (dataResult.timestamps().isEmpty() || dataResult.values().isEmpty()) {
-                continue;
-            }
-            StatAndDimentions statAndDimentions = MetricLabels.decode(dataResult.label());
-            String statString = statAndDimentions.stat;
-            String labelsKey = statAndDimentions.dimetionsAsString;
-            Instant timestamp = dataResult.timestamps().get(0);
-            Double value = dataResult.values().get(0);
-            MetricRuleData metricRuleData =
-                    res.getOrDefault(labelsKey, new MetricRuleData(timestamp));
-            Statistic stat = Statistic.fromValue(statString);
-            if (stat == Statistic.UNKNOWN_TO_SDK_VERSION) {
-                metricRuleData.extendedValues.put(statString, value);
-            } else {
-                metricRuleData.statisticValues.put(stat, value);
-            }
-            res.put(labelsKey, metricRuleData);
-        }
-        return res;
-    }
-
-    GetMetricDataDataGetter(CloudWatchClient client, long start, MetricRule rule,
-            Counter apiRequestsCounter, Counter metricsRequestedCounter,
-            List<List<Dimension>> dimentionsList) {
-        this.client = client;
-        this.start = start;
-        this.rule = rule;
-        this.apiRequestsCounter = apiRequestsCounter;
-        this.metricsRequestedCounter = metricsRequestedCounter;
-        this.metricRequestedForBilling = 0d;
-        this.results = fetchAllDataPoints(dimentionsList);
-    }
-
-    @Override
-    public MetricRuleData metricRuleDataFor(List<Dimension> dimensions) {
-        return results.get(dimentionsToKey(dimensions));
-    }
-
-    static private class StatAndDimentions {
-        String dimetionsAsString;
-        String stat;
-
-        StatAndDimentions(String stat, String dimetionsAsString) {
-            this.stat = stat;
-            this.dimetionsAsString = dimetionsAsString;
-        }
-    }
-
-    static class MetricLabels {
-        static String labelFor(String stat, List<Dimension> dimensions) {
-            return String.format("%s/%s", stat, dimentionsToKey(dimensions));
-        }
-
-        static StatAndDimentions decode(String label) {
-            String[] labelParts = label.split("/", 2);
-            if (labelParts.length != 2) {
-                throw new UnexpectedLabel(label);
-            }
-            String statString = labelParts[0];
-            String labelsKey = labelParts[1];
-            return new StatAndDimentions(statString, labelsKey);
-        }
-
-        static class UnexpectedLabel extends RuntimeException {
-            public UnexpectedLabel(String label) {
-                super(String.format("Cannot decode label %s", label));
-            }
-        }
-    }
-
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/GetMetricStatisticsDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricStatisticsDataGetter.java
@@ -1,93 +1,97 @@
 package io.prometheus.cloudwatch;
 
+import io.prometheus.client.Counter;
+import io.prometheus.cloudwatch.CloudWatchCollector.MetricRule;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import io.prometheus.cloudwatch.CloudWatchCollector.MetricRule;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest;
 import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse;
 import software.amazon.awssdk.services.cloudwatch.model.Statistic;
-import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
-import io.prometheus.client.Counter;
 
 class GetMetricStatisticsDataGetter implements DataGetter {
-    private long start;
-    private MetricRule rule;
-    private CloudWatchClient client;
-    private Counter apiRequestsCounter;
-    private Counter metricsRequestedCounter;
+  private long start;
+  private MetricRule rule;
+  private CloudWatchClient client;
+  private Counter apiRequestsCounter;
+  private Counter metricsRequestedCounter;
 
-    GetMetricStatisticsDataGetter(CloudWatchClient client, long start, MetricRule rule, Counter apiRequestsCounter, Counter metricsRequestedCounter) {
-        this.client = client;
-        this.start = start;
-        this.rule = rule;
-        this.apiRequestsCounter = apiRequestsCounter;
-        this.metricsRequestedCounter = metricsRequestedCounter;
-    }
+  GetMetricStatisticsDataGetter(
+      CloudWatchClient client,
+      long start,
+      MetricRule rule,
+      Counter apiRequestsCounter,
+      Counter metricsRequestedCounter) {
+    this.client = client;
+    this.start = start;
+    this.rule = rule;
+    this.apiRequestsCounter = apiRequestsCounter;
+    this.metricsRequestedCounter = metricsRequestedCounter;
+  }
 
-    private GetMetricStatisticsRequest.Builder metricStatisticsRequestBuilder() {
-        Date startDate = new Date(start - 1000 * rule.delaySeconds);
-        Date endDate = new Date(start - 1000 * (rule.delaySeconds + rule.rangeSeconds));
-        GetMetricStatisticsRequest.Builder builder = GetMetricStatisticsRequest.builder();
-        builder.namespace(rule.awsNamespace);
-        builder.metricName(rule.awsMetricName);
-        builder.statistics(rule.awsStatistics);
-        builder.extendedStatistics(rule.awsExtendedStatistics);
-        builder.endTime(startDate.toInstant());
-        builder.startTime(endDate.toInstant());
-        builder.period(rule.periodSeconds);
-        return builder;
-    }
+  private GetMetricStatisticsRequest.Builder metricStatisticsRequestBuilder() {
+    Date startDate = new Date(start - 1000 * rule.delaySeconds);
+    Date endDate = new Date(start - 1000 * (rule.delaySeconds + rule.rangeSeconds));
+    GetMetricStatisticsRequest.Builder builder = GetMetricStatisticsRequest.builder();
+    builder.namespace(rule.awsNamespace);
+    builder.metricName(rule.awsMetricName);
+    builder.statistics(rule.awsStatistics);
+    builder.extendedStatistics(rule.awsExtendedStatistics);
+    builder.endTime(startDate.toInstant());
+    builder.startTime(endDate.toInstant());
+    builder.period(rule.periodSeconds);
+    return builder;
+  }
 
-    @Override
-    public MetricRuleData metricRuleDataFor(List<Dimension> dimensions) {
-        GetMetricStatisticsRequest.Builder builder = metricStatisticsRequestBuilder();
-        builder.dimensions(dimensions);
-        GetMetricStatisticsResponse response = client.getMetricStatistics(builder.build());
-        apiRequestsCounter.labels("getMetricStatistics", rule.awsNamespace).inc();
-        metricsRequestedCounter.labels(rule.awsMetricName, rule.awsNamespace).inc();
-        Datapoint latestDp = getNewestDatapoint(response.datapoints());
-        return toMetricValues(latestDp);
-    }
+  @Override
+  public MetricRuleData metricRuleDataFor(List<Dimension> dimensions) {
+    GetMetricStatisticsRequest.Builder builder = metricStatisticsRequestBuilder();
+    builder.dimensions(dimensions);
+    GetMetricStatisticsResponse response = client.getMetricStatistics(builder.build());
+    apiRequestsCounter.labels("getMetricStatistics", rule.awsNamespace).inc();
+    metricsRequestedCounter.labels(rule.awsMetricName, rule.awsNamespace).inc();
+    Datapoint latestDp = getNewestDatapoint(response.datapoints());
+    return toMetricValues(latestDp);
+  }
 
-    private Datapoint getNewestDatapoint(java.util.List<Datapoint> datapoints) {
-        Datapoint newest = null;
-        for (Datapoint d : datapoints) {
-            if (newest == null || newest.timestamp().isBefore(d.timestamp())) {
-                newest = d;
-            }
-        }
-        return newest;
+  private Datapoint getNewestDatapoint(java.util.List<Datapoint> datapoints) {
+    Datapoint newest = null;
+    for (Datapoint d : datapoints) {
+      if (newest == null || newest.timestamp().isBefore(d.timestamp())) {
+        newest = d;
+      }
     }
+    return newest;
+  }
 
-    private MetricRuleData toMetricValues(Datapoint dp) {
-        if (dp == null) {
-            return null;
-        }
-        MetricRuleData values = new MetricRuleData(dp.timestamp());
-        if (dp.sum() != null) {
-            values.statisticValues.put(Statistic.SUM, dp.sum());
-        }
-        if (dp.sampleCount() != null) {
-            values.statisticValues.put(Statistic.SAMPLE_COUNT, dp.sampleCount());
-        }
-        if (dp.minimum() != null) {
-            values.statisticValues.put(Statistic.MINIMUM, dp.minimum());
-        }
-        if (dp.maximum() != null) {
-            values.statisticValues.put(Statistic.MAXIMUM, dp.maximum());
-        }
-        if (dp.average() != null) {
-            values.statisticValues.put(Statistic.AVERAGE, dp.average());
-        }
-        if (dp.extendedStatistics() != null) {
-            for (Map.Entry<String, Double> entry : dp.extendedStatistics().entrySet()) {
-                values.extendedValues.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return values;
+  private MetricRuleData toMetricValues(Datapoint dp) {
+    if (dp == null) {
+      return null;
     }
+    MetricRuleData values = new MetricRuleData(dp.timestamp());
+    if (dp.sum() != null) {
+      values.statisticValues.put(Statistic.SUM, dp.sum());
+    }
+    if (dp.sampleCount() != null) {
+      values.statisticValues.put(Statistic.SAMPLE_COUNT, dp.sampleCount());
+    }
+    if (dp.minimum() != null) {
+      values.statisticValues.put(Statistic.MINIMUM, dp.minimum());
+    }
+    if (dp.maximum() != null) {
+      values.statisticValues.put(Statistic.MAXIMUM, dp.maximum());
+    }
+    if (dp.average() != null) {
+      values.statisticValues.put(Statistic.AVERAGE, dp.average());
+    }
+    if (dp.extendedStatistics() != null) {
+      for (Map.Entry<String, Double> entry : dp.extendedStatistics().entrySet()) {
+        values.extendedValues.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return values;
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -1,17 +1,18 @@
 package io.prometheus.cloudwatch;
 
+import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 public class HealthServlet extends HttpServlet {
-	private static final long serialVersionUID = 5543118274931292897L;
+  private static final long serialVersionUID = 5543118274931292897L;
 
-	@Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setContentType("text/plain");
-        resp.getWriter().print("ok");
-    }
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    resp.setContentType("text/plain");
+    resp.getWriter().print("ok");
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/HomePageServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HomePageServlet.java
@@ -1,27 +1,30 @@
 package io.prometheus.cloudwatch;
 
+import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 public class HomePageServlet extends HttpServlet {
-	private static final long serialVersionUID = 3239704246954810347L;
+  private static final long serialVersionUID = 3239704246954810347L;
 
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setContentType("text/html");
-        try {
-        resp.getWriter().print("<html>\n"
-                + "<head><title>CloudWatch Exporter</title></head>\n"
-                + "<body>\n"
-                + "<h1>CloudWatch Exporter</h1>\n"
-                + "<p><a href=\"/metrics\">Metrics</a></p>\n"
-                + "</body>\n"
-                + "</html>");
-        } catch (IOException e) {
-            // Ignored
-        }
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    resp.setContentType("text/html");
+    try {
+      resp.getWriter()
+          .print(
+              "<html>\n"
+                  + "<head><title>CloudWatch Exporter</title></head>\n"
+                  + "<body>\n"
+                  + "<h1>CloudWatch Exporter</h1>\n"
+                  + "<p><a href=\"/metrics\">Metrics</a></p>\n"
+                  + "</body>\n"
+                  + "</html>");
+    } catch (IOException e) {
+      // Ignored
     }
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
+++ b/src/main/java/io/prometheus/cloudwatch/ReloadSignalHandler.java
@@ -6,17 +6,19 @@ import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
 class ReloadSignalHandler {
-    private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
-    protected static void start(final CloudWatchCollector collector) {
-        Signal.handle(new Signal("HUP"), new SignalHandler() {
-            public void handle(Signal signal) {
-                try {
-                    collector.reloadConfig();
-                } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Configuration reload failed", e);
-                }
+  protected static void start(final CloudWatchCollector collector) {
+    Signal.handle(
+        new Signal("HUP"),
+        new SignalHandler() {
+          public void handle(Signal signal) {
+            try {
+              collector.reloadConfig();
+            } catch (Exception e) {
+              LOGGER.log(Level.WARNING, "Configuration reload failed", e);
             }
+          }
         });
-    }
+  }
 }

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -1,47 +1,43 @@
 package io.prometheus.cloudwatch;
 
+import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.client.hotspot.DefaultExports;
 import java.io.FileReader;
-
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
-import io.prometheus.client.exporter.MetricsServlet;
-import io.prometheus.client.hotspot.DefaultExports;
-
 public class WebServer {
 
-    public static String configFilePath;
+  public static String configFilePath;
 
-    public static void main(String[] args) throws Exception {
-        if (args.length < 2) {
-            System.err.println("Usage: WebServer <port> <yml configuration file>");
-            System.exit(1);
-        }
-
-        configFilePath = args[1];
-        CloudWatchCollector collector = null;
-        new BuildInfoCollector().register();
-        try (
-          FileReader reader = new FileReader(configFilePath);
-        ) {
-          collector = new CloudWatchCollector(reader).register();
-        }
-        DefaultExports.initialize();
-
-        ReloadSignalHandler.start(collector);
-
-        int port = Integer.parseInt(args[0]);
-        Server server = new Server(port);
-        ServletContextHandler context = new ServletContextHandler();
-        context.setContextPath("/");
-        server.setHandler(context);
-        context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-        context.addServlet(new ServletHolder(new DynamicReloadServlet(collector)), "/-/reload");
-        context.addServlet(new ServletHolder(new HealthServlet()), "/-/healthy");
-        context.addServlet(new ServletHolder(new HealthServlet()), "/-/ready");
-        context.addServlet(new ServletHolder(new HomePageServlet()), "/");
-        server.start();
-        server.join();
+  public static void main(String[] args) throws Exception {
+    if (args.length < 2) {
+      System.err.println("Usage: WebServer <port> <yml configuration file>");
+      System.exit(1);
     }
+
+    configFilePath = args[1];
+    CloudWatchCollector collector = null;
+    new BuildInfoCollector().register();
+    try (FileReader reader = new FileReader(configFilePath); ) {
+      collector = new CloudWatchCollector(reader).register();
+    }
+    DefaultExports.initialize();
+
+    ReloadSignalHandler.start(collector);
+
+    int port = Integer.parseInt(args[0]);
+    Server server = new Server(port);
+    ServletContextHandler context = new ServletContextHandler();
+    context.setContextPath("/");
+    server.setHandler(context);
+    context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+    context.addServlet(new ServletHolder(new DynamicReloadServlet(collector)), "/-/reload");
+    context.addServlet(new ServletHolder(new HealthServlet()), "/-/healthy");
+    context.addServlet(new ServletHolder(new HealthServlet()), "/-/ready");
+    context.addServlet(new ServletHolder(new HomePageServlet()), "/");
+    server.start();
+    server.join();
+  }
 }

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -1,31 +1,28 @@
 package io.prometheus.cloudwatch;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-import io.prometheus.cloudwatch.RequestsMatchers.*;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import io.prometheus.cloudwatch.RequestsMatchers.*;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
-import java.util.Properties;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.*;
 import software.amazon.awssdk.services.resourcegroupstaggingapi.ResourceGroupsTaggingApiClient;
@@ -49,147 +46,306 @@ public class CloudWatchCollectorTest {
   @Test
   public void testMetricPeriod() {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  period_seconds: 100\n  range_seconds: 200\n  delay_seconds: 300", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  period_seconds: 100\n  range_seconds: 200\n  delay_seconds: 300",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
     Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest) any()))
-            .thenReturn(GetMetricStatisticsResponse.builder().build());
+        .thenReturn(GetMetricStatisticsResponse.builder().build());
 
-    registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""});
+    registry.getSampleValue(
+        "aws_elb_request_count_average",
+        new String[] {"job", "instance"},
+        new String[] {"aws_elb", ""});
 
-
-    Mockito.verify(cloudWatchClient).getMetricStatistics(argThat(
-            new GetMetricStatisticsRequestMatcher()
-                    .Namespace("AWS/ELB")
-                    .MetricName("RequestCount")
-                    .Period(100)
-    ));
+    Mockito.verify(cloudWatchClient)
+        .getMetricStatistics(
+            argThat(
+                new GetMetricStatisticsRequestMatcher()
+                    .Namespace("AWS/ELB").MetricName("RequestCount").Period(100)));
   }
 
   @Test
   public void testMetricPeriodUsingGetMetricData() {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  period_seconds: 100\n  range_seconds: 200\n  delay_seconds: 300\n  use_get_metric_data: true\n", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  period_seconds: 100\n  range_seconds: 200\n  delay_seconds: 300\n  use_get_metric_data: true\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
     Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest) any()))
-            .thenReturn(GetMetricStatisticsResponse.builder().build());
+        .thenReturn(GetMetricStatisticsResponse.builder().build());
 
     Mockito.when(cloudWatchClient.getMetricData((GetMetricDataRequest) any()))
-            .thenReturn(GetMetricDataResponse.builder().build());
-    registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""});
+        .thenReturn(GetMetricDataResponse.builder().build());
+    registry.getSampleValue(
+        "aws_elb_request_count_average",
+        new String[] {"job", "instance"},
+        new String[] {"aws_elb", ""});
 
-    Mockito.verify(cloudWatchClient, never()).getMetricStatistics(isA(GetMetricStatisticsRequest.class));
-    Mockito.verify(cloudWatchClient).getMetricData(argThat(
-      new GetMetricDataRequestMatcher().Query(
-        new MetricDataQueryMatcher().MetricStat(
-          new MetricStatMatcher().Period(100).metric(
-            new MetricMatcher()
-            .Namespace("AWS/ELB")
-            .MetricName("RequestCount")
-          )
-        ))
-    ));
+    Mockito.verify(cloudWatchClient, never())
+        .getMetricStatistics(isA(GetMetricStatisticsRequest.class));
+    Mockito.verify(cloudWatchClient)
+        .getMetricData(
+            argThat(
+                new GetMetricDataRequestMatcher()
+                    .Query(
+                        new MetricDataQueryMatcher()
+                            .MetricStat(
+                                new MetricStatMatcher()
+                                    .Period(100)
+                                        .metric(
+                                            new MetricMatcher()
+                                                .Namespace("AWS/ELB")
+                                                    .MetricName("RequestCount"))))));
   }
-  
+
   @Test
   public void testDefaultPeriod() {
     new CloudWatchCollector(
-                    "---\nregion: reg\nperiod_seconds: 100\nrange_seconds: 200\ndelay_seconds: 300\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nperiod_seconds: 100\nrange_seconds: 200\ndelay_seconds: 300\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
     Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest) any()))
-            .thenReturn(GetMetricStatisticsResponse.builder().build());
+        .thenReturn(GetMetricStatisticsResponse.builder().build());
 
-    registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""});
+    registry.getSampleValue(
+        "aws_elb_request_count_average",
+        new String[] {"job", "instance"},
+        new String[] {"aws_elb", ""});
 
-
-    Mockito.verify(cloudWatchClient).getMetricStatistics((GetMetricStatisticsRequest) argThat(
-            new GetMetricStatisticsRequestMatcher()
-                    .Namespace("AWS/ELB")
-                    .MetricName("RequestCount")
-                    .Period(100)
-    ));
+    Mockito.verify(cloudWatchClient)
+        .getMetricStatistics(
+            (GetMetricStatisticsRequest)
+                argThat(
+                    new GetMetricStatisticsRequestMatcher()
+                        .Namespace("AWS/ELB").MetricName("RequestCount").Period(100)));
   }
 
   @Test
   public void testAllStatistics() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(1.0)
-                .maximum(2.0).minimum(3.0).sampleCount(4.0).sum(5.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB").MetricName("RequestCount"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder()
+                        .timestamp(new Date().toInstant())
+                        .average(1.0)
+                        .maximum(2.0)
+                        .minimum(3.0)
+                        .sampleCount(4.0)
+                        .sum(5.0)
+                        .build())
+                .build());
 
-    assertEquals(1.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_maximum", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_elb_request_count_minimum", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(4.0, registry.getSampleValue("aws_elb_request_count_sample_count", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(5.0, registry.getSampleValue("aws_elb_request_count_sum", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_maximum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_minimum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        4.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_sample_count",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        5.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_sum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
   }
 
   @Test
   public void testAllStatisticsUsingGetMetricData() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  use_get_metric_data: true\n", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  use_get_metric_data: true\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
     List<Instant> timestamps = List.of(new Date().toInstant());
-    MetricMatcher metricMatcher = new MetricMatcher()
-          .Namespace("AWS/ELB")
-          .MetricName("RequestCount");
-          
-    Mockito.when(cloudWatchClient.getMetricData((GetMetricDataRequest) argThat(
-        new GetMetricDataRequestMatcher()
-        .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("Average").metric(metricMatcher)))
-        .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("Maximum").metric(metricMatcher)))
-        .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("Minimum").metric(metricMatcher)))
-        .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("SampleCount").metric(metricMatcher)))
-        .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("Sum").metric(metricMatcher)))
-        )))
-        .thenReturn(GetMetricDataResponse.builder().metricDataResults(
-          List.of(
-            MetricDataResult.builder().label("Average/").values(List.of(Double.valueOf(1.0))).timestamps(timestamps).build(),
-            MetricDataResult.builder().label("Maximum/").values(List.of(Double.valueOf(2.0))).timestamps(timestamps).build(),
-            MetricDataResult.builder().label("Minimum/").values(List.of(Double.valueOf(3.0))).timestamps(timestamps).build(),
-            MetricDataResult.builder().label("SampleCount/").values(List.of(Double.valueOf(4.0))).timestamps(timestamps).build(),
-            MetricDataResult.builder().label("Sum/").values(List.of(Double.valueOf(5.0))).timestamps(timestamps).build())).build());
-            
-    assertEquals(1.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_maximum", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_elb_request_count_minimum", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(4.0, registry.getSampleValue("aws_elb_request_count_sample_count", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(5.0, registry.getSampleValue("aws_elb_request_count_sum", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
+    MetricMatcher metricMatcher =
+        new MetricMatcher().Namespace("AWS/ELB").MetricName("RequestCount");
+
+    Mockito.when(
+            cloudWatchClient.getMetricData(
+                (GetMetricDataRequest)
+                    argThat(
+                        new GetMetricDataRequestMatcher()
+                            .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("Average").metric(metricMatcher)))
+                                .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("Maximum").metric(metricMatcher)))
+                                .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("Minimum").metric(metricMatcher)))
+                                .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("SampleCount").metric(metricMatcher)))
+                                .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("Sum").metric(metricMatcher))))))
+        .thenReturn(
+            GetMetricDataResponse.builder()
+                .metricDataResults(
+                    List.of(
+                        MetricDataResult.builder()
+                            .label("Average/")
+                            .values(List.of(Double.valueOf(1.0)))
+                            .timestamps(timestamps)
+                            .build(),
+                        MetricDataResult.builder()
+                            .label("Maximum/")
+                            .values(List.of(Double.valueOf(2.0)))
+                            .timestamps(timestamps)
+                            .build(),
+                        MetricDataResult.builder()
+                            .label("Minimum/")
+                            .values(List.of(Double.valueOf(3.0)))
+                            .timestamps(timestamps)
+                            .build(),
+                        MetricDataResult.builder()
+                            .label("SampleCount/")
+                            .values(List.of(Double.valueOf(4.0)))
+                            .timestamps(timestamps)
+                            .build(),
+                        MetricDataResult.builder()
+                            .label("Sum/")
+                            .values(List.of(Double.valueOf(5.0)))
+                            .timestamps(timestamps)
+                            .build()))
+                .build());
+
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_maximum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_minimum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        4.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_sample_count",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        5.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_sum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
   }
 
   @Test
   public void testCloudwatchTimestamps() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  set_timestamp: true\n- aws_namespace: AWS/ELB\n  aws_metric_name: HTTPCode_Backend_2XX\n  set_timestamp: false"
-            , cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  set_timestamp: true\n- aws_namespace: AWS/ELB\n  aws_metric_name: HTTPCode_Backend_2XX\n  set_timestamp: false",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
     Date timestamp = new Date();
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-            new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount"))))
-            .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-                    Datapoint.builder().timestamp(timestamp.toInstant()).average(1.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB").MetricName("RequestCount"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(timestamp.toInstant()).average(1.0).build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-            new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("HTTPCode_Backend_2XX"))))
-            .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-                    Datapoint.builder().timestamp(timestamp.toInstant()).average(1.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB").MetricName("HTTPCode_Backend_2XX"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(timestamp.toInstant()).average(1.0).build())
+                .build());
 
     assertMetricTimestampEquals(registry, "aws_elb_request_count_average", timestamp.getTime());
     assertMetricTimestampEquals(registry, "aws_elb_httpcode_backend_2_xx_average", null);
-
   }
 
-  void assertMetricTimestampEquals(CollectorRegistry registry, String name, Long expectedTimestamp) {
-    Enumeration<Collector.MetricFamilySamples> metricFamilySamplesEnumeration = registry.metricFamilySamples();
+  void assertMetricTimestampEquals(
+      CollectorRegistry registry, String name, Long expectedTimestamp) {
+    Enumeration<Collector.MetricFamilySamples> metricFamilySamplesEnumeration =
+        registry.metricFamilySamples();
     Set<String> metricNames = new HashSet<String>();
-    while(metricFamilySamplesEnumeration.hasMoreElements()) {
+    while (metricFamilySamplesEnumeration.hasMoreElements()) {
       Collector.MetricFamilySamples samples = metricFamilySamplesEnumeration.nextElement();
-      for(Collector.MetricFamilySamples.Sample s: samples.samples) {
+      for (Collector.MetricFamilySamples.Sample s : samples.samples) {
         metricNames.add(s.name);
-        if(s.name.equals(name)) {
-          assertEquals(expectedTimestamp, (Long)s.timestampMs);
+        if (s.name.equals(name)) {
+          assertEquals(expectedTimestamp, (Long) s.timestampMs);
           return;
         }
       }
@@ -200,491 +356,1451 @@ public class CloudWatchCollectorTest {
   @Test
   public void testUsesNewestDatapoint() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date(1).toInstant()).average(1.0).build(),
-                Datapoint.builder().timestamp(new Date(3).toInstant()).average(3.0).build(),
-                Datapoint.builder().timestamp(new Date(2).toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB").MetricName("RequestCount"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date(1).toInstant()).average(1.0).build(),
+                    Datapoint.builder().timestamp(new Date(3).toInstant()).average(3.0).build(),
+                    Datapoint.builder().timestamp(new Date(2).toInstant()).average(2.0).build())
+                .build());
 
-    assertEquals(3.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
   }
 
   @Test
   public void testDimensions() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName", cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-                Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build()).build(),
-                Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build(), Dimension.builder().name("ThisExtraDimensionIsIgnored").value("dummy").build()).build(),
-                Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("b").build(), Dimension.builder().name("LoadBalancerName").value("myOtherLB").build()).build()
-                ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myOtherLB"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build(),
+                            Dimension.builder()
+                                .name("ThisExtraDimensionIsIgnored")
+                                .value("dummy")
+                                .build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("b").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myOtherLB").build())
+                        .build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "b", "myOtherLB"}), .01);
-    assertNull(registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name", "this_extra_dimension_is_ignored"}, new String[]{"aws_elb", "", "a", "myLB", "dummy"}));
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "b")
+                                .Dimension("LoadBalancerName", "myOtherLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "b", "myOtherLB"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {
+              "job",
+              "instance",
+              "availability_zone",
+              "load_balancer_name",
+              "this_extra_dimension_is_ignored"
+            },
+            new String[] {"aws_elb", "", "a", "myLB", "dummy"}));
   }
 
   @Test
   public void testDimensionSelect() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB", cloudWatchClient, taggingClient).register(registry);
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("b").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myOtherLB").build()).build()
-            ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("b").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myOtherLB").build())
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myLB"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "b")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "b", "myLB"}), .01);
-    assertNull(registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myOtherLB"}));
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "b", "myLB"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myOtherLB"}));
   }
 
   @Test
   public void testAllSelectDimensionsKnown() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB\n    AvailabilityZone:\n    - a\n    - b", cloudWatchClient, taggingClient).register(registry);
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-            new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB"))))
-            .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB\n    AvailabilityZone:\n    - a\n    - b",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-            new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myLB"))))
-            .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "b")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "b", "myLB"}), .01);
-    assertNull(registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myOtherLB"}));
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "b", "myLB"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myOtherLB"}));
   }
 
   @Test
   public void testAllSelectDimensionsKnownUsingGetMetricData() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB\n    AvailabilityZone:\n    - a\n    - b\n  use_get_metric_data: true\n", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB\n    AvailabilityZone:\n    - a\n    - b\n  use_get_metric_data: true\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
     List<Instant> timestamps = List.of(new Date().toInstant());
-    MetricMatcher firstMetric = new MetricMatcher()
-          .Namespace("AWS/ELB")
-          .MetricName("RequestCount")
-          .Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB");
+    MetricMatcher firstMetric =
+        new MetricMatcher()
+            .Namespace("AWS/ELB")
+                .MetricName("RequestCount")
+                .Dimension("AvailabilityZone", "a")
+                .Dimension("LoadBalancerName", "myLB");
 
-    MetricMatcher secondMetric = new MetricMatcher()
-          .Namespace("AWS/ELB")
-          .MetricName("RequestCount")
-          .Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myLB");
+    MetricMatcher secondMetric =
+        new MetricMatcher()
+            .Namespace("AWS/ELB")
+                .MetricName("RequestCount")
+                .Dimension("AvailabilityZone", "b")
+                .Dimension("LoadBalancerName", "myLB");
 
-    Mockito.when(cloudWatchClient.getMetricData((GetMetricDataRequest) argThat(
-      new GetMetricDataRequestMatcher()
-      .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("Average").metric(firstMetric)))
-      .Query(new MetricDataQueryMatcher().MetricStat(new MetricStatMatcher().Stat("Average").metric(secondMetric)))
-      )))
-      .thenReturn(GetMetricDataResponse.builder().metricDataResults(
-        List.of(
-          MetricDataResult.builder().label("Average/AvailabilityZone=a,LoadBalancerName=myLB").values(List.of(Double.valueOf(2.0))).timestamps(timestamps).build(),
-          MetricDataResult.builder().label("Average/AvailabilityZone=b,LoadBalancerName=myLB").values(List.of(Double.valueOf(3.0))).timestamps(timestamps).build()
-          )).build());
+    Mockito.when(
+            cloudWatchClient.getMetricData(
+                (GetMetricDataRequest)
+                    argThat(
+                        new GetMetricDataRequestMatcher()
+                            .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("Average").metric(firstMetric)))
+                                .Query(
+                                    new MetricDataQueryMatcher()
+                                        .MetricStat(
+                                            new MetricStatMatcher()
+                                                .Stat("Average").metric(secondMetric))))))
+        .thenReturn(
+            GetMetricDataResponse.builder()
+                .metricDataResults(
+                    List.of(
+                        MetricDataResult.builder()
+                            .label("Average/AvailabilityZone=a,LoadBalancerName=myLB")
+                            .values(List.of(Double.valueOf(2.0)))
+                            .timestamps(timestamps)
+                            .build(),
+                        MetricDataResult.builder()
+                            .label("Average/AvailabilityZone=b,LoadBalancerName=myLB")
+                            .values(List.of(Double.valueOf(3.0)))
+                            .timestamps(timestamps)
+                            .build()))
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "b", "myLB"}), .01);
-    assertNull(registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myOtherLB"}));
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "b", "myLB"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myOtherLB"}));
   }
 
   @Test
   public void testDimensionSelectRegex() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select_regex:\n    LoadBalancerName:\n    - myLB(.*)", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select_regex:\n    LoadBalancerName:\n    - myLB(.*)",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest) argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB1").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("b").build(), Dimension.builder().name("LoadBalancerName").value("myLB2").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myOtherLB").build()).build()
-            ).build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB1").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("b").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB2").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myOtherLB").build())
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest) argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB1"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB1"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest) argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myLB2"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "b")
+                                .Dimension("LoadBalancerName", "myLB2"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB1"}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "b", "myLB2"}), .01);
-    assertNull(registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myOtherLB"}));
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB1"}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "b", "myLB2"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myOtherLB"}));
   }
 
   @Test
   public void testGetDimensionsUsesNextToken() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB", cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName"))))
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  aws_dimension_select:\n    LoadBalancerName:\n    - myLB",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
+
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName"))))
         .thenReturn(ListMetricsResponse.builder().nextToken("ABC").build());
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName").NextToken("ABC"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build()).build()).build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName")
+                                .NextToken("ABC"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer_name"}, new String[]{"aws_elb", "", "a", "myLB"}), .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
   }
 
   @Test
   public void testExtendedStatistics() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: Latency\n  aws_extended_statistics:\n  - p95\n  - p99.99", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: Latency\n  aws_extended_statistics:\n  - p95\n  - p99.99",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
     HashMap<String, Double> extendedStatistics = new HashMap<String, Double>();
     extendedStatistics.put("p95", 1.0);
     extendedStatistics.put("p99.99", 2.0);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("Latency"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).extendedStatistics(extendedStatistics).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB").MetricName("Latency"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder()
+                        .timestamp(new Date().toInstant())
+                        .extendedStatistics(extendedStatistics)
+                        .build())
+                .build());
 
-    assertEquals(1.0, registry.getSampleValue("aws_elb_latency_p95", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_elb_latency_p99_99", new String[]{"job", "instance"}, new String[]{"aws_elb", ""}), .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_elb_latency_p95", new String[] {"job", "instance"}, new String[] {"aws_elb", ""}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_latency_p99_99",
+            new String[] {"job", "instance"},
+            new String[] {"aws_elb", ""}),
+        .01);
   }
 
   @Test
   public void testDynamoIndexDimensions() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: ConsumedReadCapacityUnits\n  aws_dimensions:\n  - TableName\n  - GlobalSecondaryIndexName\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: OnlineIndexConsumedWriteCapacity\n  aws_dimensions:\n  - TableName\n  - GlobalSecondaryIndexName\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: ConsumedReadCapacityUnits\n  aws_dimensions:\n  - TableName", cloudWatchClient, taggingClient).register(registry);
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimensions("TableName", "GlobalSecondaryIndexName"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-          Metric.builder().dimensions(Dimension.builder().name("TableName").value("myTable").build(), Dimension.builder().name("GlobalSecondaryIndexName").value("myIndex").build()).build()).build());
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("OnlineIndexConsumedWriteCapacity").Dimensions("TableName", "GlobalSecondaryIndexName"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-          Metric.builder().dimensions(Dimension.builder().name("TableName").value("myTable").build(), Dimension.builder().name("GlobalSecondaryIndexName").value("myIndex").build()).build()).build());
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimensions("TableName"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-          Metric.builder().dimensions(Dimension.builder().name("TableName").value("myTable").build()).build()).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: ConsumedReadCapacityUnits\n  aws_dimensions:\n  - TableName\n  - GlobalSecondaryIndexName\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: OnlineIndexConsumedWriteCapacity\n  aws_dimensions:\n  - TableName\n  - GlobalSecondaryIndexName\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: ConsumedReadCapacityUnits\n  aws_dimensions:\n  - TableName",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("ConsumedReadCapacityUnits")
+                                .Dimensions("TableName", "GlobalSecondaryIndexName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("TableName").value("myTable").build(),
+                            Dimension.builder()
+                                .name("GlobalSecondaryIndexName")
+                                .value("myIndex")
+                                .build())
+                        .build())
+                .build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("OnlineIndexConsumedWriteCapacity")
+                                .Dimensions("TableName", "GlobalSecondaryIndexName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("TableName").value("myTable").build(),
+                            Dimension.builder()
+                                .name("GlobalSecondaryIndexName")
+                                .value("myIndex")
+                                .build())
+                        .build())
+                .build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("ConsumedReadCapacityUnits")
+                                .Dimensions("TableName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("TableName").value("myTable").build())
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimension("TableName", "myTable").Dimension("GlobalSecondaryIndexName", "myIndex"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).sum(1.0).build()).build());
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("OnlineIndexConsumedWriteCapacity").Dimension("TableName", "myTable").Dimension("GlobalSecondaryIndexName", "myIndex"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).sum(2.0).build()).build());
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("ConsumedReadCapacityUnits").Dimension("TableName", "myTable"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).sum(3.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("ConsumedReadCapacityUnits")
+                                .Dimension("TableName", "myTable")
+                                .Dimension("GlobalSecondaryIndexName", "myIndex"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(Datapoint.builder().timestamp(new Date().toInstant()).sum(1.0).build())
+                .build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("OnlineIndexConsumedWriteCapacity")
+                                .Dimension("TableName", "myTable")
+                                .Dimension("GlobalSecondaryIndexName", "myIndex"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(Datapoint.builder().timestamp(new Date().toInstant()).sum(2.0).build())
+                .build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("ConsumedReadCapacityUnits")
+                                .Dimension("TableName", "myTable"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(Datapoint.builder().timestamp(new Date().toInstant()).sum(3.0).build())
+                .build());
 
-    assertEquals(1.0, registry.getSampleValue("aws_dynamodb_consumed_read_capacity_units_index_sum", new String[]{"job", "instance", "table_name", "global_secondary_index_name"}, new String[]{"aws_dynamodb", "", "myTable", "myIndex"}), .01);
-    assertEquals(2.0, registry.getSampleValue("aws_dynamodb_online_index_consumed_write_capacity_sum", new String[]{"job", "instance", "table_name", "global_secondary_index_name"}, new String[]{"aws_dynamodb", "", "myTable", "myIndex"}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_dynamodb_consumed_read_capacity_units_sum", new String[]{"job", "instance", "table_name"}, new String[]{"aws_dynamodb", "", "myTable"}), .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_dynamodb_consumed_read_capacity_units_index_sum",
+            new String[] {"job", "instance", "table_name", "global_secondary_index_name"},
+            new String[] {"aws_dynamodb", "", "myTable", "myIndex"}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_dynamodb_online_index_consumed_write_capacity_sum",
+            new String[] {"job", "instance", "table_name", "global_secondary_index_name"},
+            new String[] {"aws_dynamodb", "", "myTable", "myIndex"}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_dynamodb_consumed_read_capacity_units_sum",
+            new String[] {"job", "instance", "table_name"},
+            new String[] {"aws_dynamodb", "", "myTable"}),
+        .01);
   }
-  
+
   @Test
   public void testDynamoNoDimensions() throws Exception {
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: AccountProvisionedReadCapacityUtilization\n", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/DynamoDB\n  aws_metric_name: AccountProvisionedReadCapacityUtilization\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/DynamoDB").MetricName("AccountProvisionedReadCapacityUtilization"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).sum(1.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/DynamoDB")
+                                .MetricName("AccountProvisionedReadCapacityUtilization"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(Datapoint.builder().timestamp(new Date().toInstant()).sum(1.0).build())
+                .build());
 
-    assertEquals(1.0, registry.getSampleValue("aws_dynamodb_account_provisioned_read_capacity_utilization_sum", new String[]{"job", "instance"}, new String[]{"aws_dynamodb", ""}), .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_dynamodb_account_provisioned_read_capacity_utilization_sum",
+            new String[] {"job", "instance"},
+            new String[] {"aws_dynamodb", ""}),
+        .01);
   }
+
   @Test
   public void testTagSelectEC2() throws Exception {
     // Testing "aws_tag_select" with an EC2
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n", 
-        cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
-        new GetResourcesRequestMatcher().ResourceTypeFilter("ec2:instance").TagFilter("Monitoring", Arrays.asList("enabled")))))
-        .thenReturn(GetResourcesResponse.builder().resourceTagMappingList(
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1").build()).build());
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimensions("InstanceId"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-1").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-2").build()).build()
-        ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-1"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-2"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            taggingClient.getResources(
+                (GetResourcesRequest)
+                    argThat(
+                        new GetResourcesRequestMatcher()
+                            .ResourceTypeFilter("ec2:instance")
+                                .TagFilter("Monitoring", Arrays.asList("enabled")))))
+        .thenReturn(
+            GetResourcesResponse.builder()
+                .resourceTagMappingList(
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1")
+                        .build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
-    assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimensions("InstanceId"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-1").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-2").build())
+                        .build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-1"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-2"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-1"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-2"}));
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"
+            }),
+        .01);
   }
-  
+
   @Test
   public void testTagSelectALB() throws Exception {
-    // Testing "aws_tag_select" with an ALB, which have a fairly complex ARN 
+    // Testing "aws_tag_select" with an ALB, which have a fairly complex ARN
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ApplicationELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancer\n  aws_tag_select:\n    resource_type_selection: \"elasticloadbalancing:loadbalancer/app\"\n    resource_id_dimension: LoadBalancer\n    tag_selections:\n      Monitoring: [enabled]\n", 
-        cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
-        new GetResourcesRequestMatcher().ResourceTypeFilter("elasticloadbalancing:loadbalancer/app").TagFilter("Monitoring", Arrays.asList("enabled")))))
-        .thenReturn(GetResourcesResponse.builder().resourceTagMappingList(
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:elasticloadbalancing:us-east-1:121212121212:loadbalancer/app/myLB/123").build()).build());
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/ApplicationELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancer"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancer").value("app/myLB/123").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("b").build(), Dimension.builder().name("LoadBalancer").value("app/myLB/123").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancer").value("app/myOtherLB/456").build()).build()
-            ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ApplicationELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancer\n  aws_tag_select:\n    resource_type_selection: \"elasticloadbalancing:loadbalancer/app\"\n    resource_id_dimension: LoadBalancer\n    tag_selections:\n      Monitoring: [enabled]\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ApplicationELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancer", "app/myLB/123"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
+    Mockito.when(
+            taggingClient.getResources(
+                (GetResourcesRequest)
+                    argThat(
+                        new GetResourcesRequestMatcher()
+                            .ResourceTypeFilter("elasticloadbalancing:loadbalancer/app")
+                                .TagFilter("Monitoring", Arrays.asList("enabled")))))
+        .thenReturn(
+            GetResourcesResponse.builder()
+                .resourceTagMappingList(
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN(
+                            "arn:aws:elasticloadbalancing:us-east-1:121212121212:loadbalancer/app/myLB/123")
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ApplicationELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancer", "app/myLB/123"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ApplicationELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancer"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancer").value("app/myLB/123").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("b").build(),
+                            Dimension.builder().name("LoadBalancer").value("app/myLB/123").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder()
+                                .name("LoadBalancer")
+                                .value("app/myOtherLB/456")
+                                .build())
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/ApplicationELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancer", "app/myOtherLB/456"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(4.0).build()).build());
-    
-    assertEquals(2.0, registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "a", "app/myLB/123"}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "b", "app/myLB/123"}), .01);
-    assertNull(registry.getSampleValue("aws_applicationelb_request_count_average", new String[]{"job", "instance", "availability_zone", "load_balancer"}, new String[]{"aws_applicationelb", "", "a", "app/myOtherLB/456"}));
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "load_balancer", "tag_Monitoring"}, new String[]{"aws_applicationelb", "", "arn:aws:elasticloadbalancing:us-east-1:121212121212:loadbalancer/app/myLB/123", "app/myLB/123", "enabled"}), .01);
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ApplicationELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancer", "app/myLB/123"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ApplicationELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "b")
+                                .Dimension("LoadBalancer", "app/myLB/123"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ApplicationELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancer", "app/myOtherLB/456"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(4.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_applicationelb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer"},
+            new String[] {"aws_applicationelb", "", "a", "app/myLB/123"}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_applicationelb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer"},
+            new String[] {"aws_applicationelb", "", "b", "app/myLB/123"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_applicationelb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer"},
+            new String[] {"aws_applicationelb", "", "a", "app/myOtherLB/456"}));
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "load_balancer", "tag_Monitoring"},
+            new String[] {
+              "aws_applicationelb",
+              "",
+              "arn:aws:elasticloadbalancing:us-east-1:121212121212:loadbalancer/app/myLB/123",
+              "app/myLB/123",
+              "enabled"
+            }),
+        .01);
   }
-  
+
   @Test
   public void testTagSelectUsesPaginationToken() throws Exception {
     // Testing "aws_tag_select" with an EC2
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n", 
-        cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
-        new GetResourcesRequestMatcher().ResourceTypeFilter("ec2:instance").TagFilter("Monitoring", Arrays.asList("enabled")))))
-        .thenReturn(GetResourcesResponse.builder().paginationToken("ABC").resourceTagMappingList(
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1").build()).build());
-    
-    Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
-        new GetResourcesRequestMatcher().PaginationToken("ABC").ResourceTypeFilter("ec2:instance").TagFilter("Monitoring", Arrays.asList("enabled")))))
-        .thenReturn(GetResourcesResponse.builder().resourceTagMappingList(
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-2").build()).build());
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimensions("InstanceId"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-1").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-2").build()).build()
-            ).build());
+    Mockito.when(
+            taggingClient.getResources(
+                (GetResourcesRequest)
+                    argThat(
+                        new GetResourcesRequestMatcher()
+                            .ResourceTypeFilter("ec2:instance")
+                                .TagFilter("Monitoring", Arrays.asList("enabled")))))
+        .thenReturn(
+            GetResourcesResponse.builder()
+                .paginationToken("ABC")
+                .resourceTagMappingList(
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1")
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-1"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-2"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
+    Mockito.when(
+            taggingClient.getResources(
+                (GetResourcesRequest)
+                    argThat(
+                        new GetResourcesRequestMatcher()
+                            .PaginationToken("ABC")
+                                .ResourceTypeFilter("ec2:instance")
+                                .TagFilter("Monitoring", Arrays.asList("enabled")))))
+        .thenReturn(
+            GetResourcesResponse.builder()
+                .resourceTagMappingList(
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-2")
+                        .build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}), .01);
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}), .01);
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimensions("InstanceId"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-1").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-2").build())
+                        .build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-1"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-2"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-1"}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-2"}),
+        .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"
+            }),
+        .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"
+            }),
+        .01);
   }
-  
+
   @Test
   public void testNoSelection() throws Exception {
     // When no selection is made, all metrics should be returned
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n", 
-        cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimensions("InstanceId"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-1").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-2").build()).build()
-            ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-1"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-2"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimensions("InstanceId"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-1").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-2").build())
+                        .build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
-    assertEquals(3.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}), .01);
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-1"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-2"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-1"}),
+        .01);
+    assertEquals(
+        3.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-2"}),
+        .01);
   }
-  
+
   @Test
   public void testMultipleSelection() throws Exception {
     // When multiple selections are made, "and" logic should be applied on metrics
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n  aws_dimension_select:\n    InstanceId: [\"i-1\"]", 
-        cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
-        new GetResourcesRequestMatcher().ResourceTypeFilter("ec2:instance").TagFilter("Monitoring", Arrays.asList("enabled")))))
-        .thenReturn(GetResourcesResponse.builder().resourceTagMappingList(
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1").build(),
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-2").build()).build());
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimensions("InstanceId"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-1").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-2").build()).build()
-            ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n    tag_selections:\n      Monitoring: [enabled]\n  aws_dimension_select:\n    InstanceId: [\"i-1\"]",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-1"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-2"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
+    Mockito.when(
+            taggingClient.getResources(
+                (GetResourcesRequest)
+                    argThat(
+                        new GetResourcesRequestMatcher()
+                            .ResourceTypeFilter("ec2:instance")
+                                .TagFilter("Monitoring", Arrays.asList("enabled")))))
+        .thenReturn(
+            GetResourcesResponse.builder()
+                .resourceTagMappingList(
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1")
+                        .build(),
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-2")
+                        .build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
-    assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}), .01);
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimensions("InstanceId"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-1").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-2").build())
+                        .build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-1"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-2"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-1"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-2"}));
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"
+            }),
+        .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"
+            }),
+        .01);
   }
-  
+
   @Test
   public void testOptionalTagSelection() throws Exception {
-    // aws_tag_select can be used without tag_selection to activate the aws_resource_info metric on tagged (or previously tagged) resources
+    // aws_tag_select can be used without tag_selection to activate the aws_resource_info metric on
+    // tagged (or previously tagged) resources
     new CloudWatchCollector(
-        "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n  aws_dimension_select:\n    InstanceId: [\"i-1\", \"i-no-tag\"]", 
-        cloudWatchClient, taggingClient).register(registry);
-    
-    Mockito.when(taggingClient.getResources((GetResourcesRequest)argThat(
-        new GetResourcesRequestMatcher().ResourceTypeFilter("ec2:instance"))))
-        .thenReturn(GetResourcesResponse.builder().resourceTagMappingList(
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1").build(),
-            ResourceTagMapping.builder().tags(Tag.builder().key("Monitoring").value("enabled").build()).resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-2").build()).build());
-    
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-        new ListMetricsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimensions("InstanceId"))))
-        .thenReturn(ListMetricsResponse.builder().metrics(
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-1").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-2").build()).build(),
-            Metric.builder().dimensions(Dimension.builder().name("InstanceId").value("i-no-tag").build()).build()
-            ).build());
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/EC2\n  aws_metric_name: CPUUtilization\n  aws_dimensions:\n  - InstanceId\n  aws_tag_select:\n    resource_type_selection: \"ec2:instance\"\n    resource_id_dimension: InstanceId\n  aws_dimension_select:\n    InstanceId: [\"i-1\", \"i-no-tag\"]",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-1"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-2"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
-    
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-        new GetMetricStatisticsRequestMatcher().Namespace("AWS/EC2").MetricName("CPUUtilization").Dimension("InstanceId", "i-no-tag"))))
-        .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-            Datapoint.builder().timestamp(new Date().toInstant()).average(4.0).build()).build());
+    Mockito.when(
+            taggingClient.getResources(
+                (GetResourcesRequest)
+                    argThat(new GetResourcesRequestMatcher().ResourceTypeFilter("ec2:instance"))))
+        .thenReturn(
+            GetResourcesResponse.builder()
+                .resourceTagMappingList(
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-1")
+                        .build(),
+                    ResourceTagMapping.builder()
+                        .tags(Tag.builder().key("Monitoring").value("enabled").build())
+                        .resourceARN("arn:aws:ec2:us-east-1:121212121212:instance/i-2")
+                        .build())
+                .build());
 
-    assertEquals(2.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-1"}), .01);
-    assertNull(registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-2"}));
-    assertEquals(4.0, registry.getSampleValue("aws_ec2_cpuutilization_average", new String[]{"job", "instance", "instance_id"}, new String[]{"aws_ec2", "", "i-no-tag"}), .01);
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"}), .01);
-    assertEquals(1.0, registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"}), .01);
-    assertNull(registry.getSampleValue("aws_resource_info", new String[]{"job", "instance", "arn", "instance_id", "tag_Monitoring"}, new String[]{"aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-no-tag", "i-no-tag", "enabled"}));
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimensions("InstanceId"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-1").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(Dimension.builder().name("InstanceId").value("i-2").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("InstanceId").value("i-no-tag").build())
+                        .build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-1"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-2"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/EC2")
+                                .MetricName("CPUUtilization")
+                                .Dimension("InstanceId", "i-no-tag"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(4.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-1"}),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-2"}));
+    assertEquals(
+        4.0,
+        registry.getSampleValue(
+            "aws_ec2_cpuutilization_average",
+            new String[] {"job", "instance", "instance_id"},
+            new String[] {"aws_ec2", "", "i-no-tag"}),
+        .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-1", "i-1", "enabled"
+            }),
+        .01);
+    assertEquals(
+        1.0,
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2", "", "arn:aws:ec2:us-east-1:121212121212:instance/i-2", "i-2", "enabled"
+            }),
+        .01);
+    assertNull(
+        registry.getSampleValue(
+            "aws_resource_info",
+            new String[] {"job", "instance", "arn", "instance_id", "tag_Monitoring"},
+            new String[] {
+              "aws_ec2",
+              "",
+              "arn:aws:ec2:us-east-1:121212121212:instance/i-no-tag",
+              "i-no-tag",
+              "enabled"
+            }));
   }
 
   @Test
   public void testNotRecentlyActive() throws Exception {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  range_seconds: 12000", cloudWatchClient, taggingClient).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName\n  range_seconds: 12000",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
 
-    Mockito.when(cloudWatchClient.listMetrics((ListMetricsRequest)argThat(
-            new ListMetricsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimensions("AvailabilityZone", "LoadBalancerName").RecentlyActive(null))))
-            .thenReturn(ListMetricsResponse.builder().metrics(
-                    Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build()).build(),
-                    Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("a").build(), Dimension.builder().name("LoadBalancerName").value("myLB").build(), Dimension.builder().name("ThisExtraDimensionIsIgnored").value("dummy").build()).build(),
-                    Metric.builder().dimensions(Dimension.builder().name("AvailabilityZone").value("b").build(), Dimension.builder().name("LoadBalancerName").value("myOtherLB").build()).build()
-                    ).build());
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName")
+                                .RecentlyActive(null))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build(),
+                            Dimension.builder()
+                                .name("ThisExtraDimensionIsIgnored")
+                                .value("dummy")
+                                .build())
+                        .build(),
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("b").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myOtherLB").build())
+                        .build())
+                .build());
 
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-            new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "a").Dimension("LoadBalancerName", "myLB"))))
-            .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build()).build());
-    Mockito.when(cloudWatchClient.getMetricStatistics((GetMetricStatisticsRequest)argThat(
-            new GetMetricStatisticsRequestMatcher().Namespace("AWS/ELB").MetricName("RequestCount").Dimension("AvailabilityZone", "b").Dimension("LoadBalancerName", "myOtherLB"))))
-            .thenReturn(GetMetricStatisticsResponse.builder().datapoints(
-                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build()).build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "b")
+                                .Dimension("LoadBalancerName", "myOtherLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(3.0).build())
+                .build());
 
-    registry.getSampleValue("aws_elb_request_count_average", new String[]{"job", "instance"}, new String[]{"aws_elb", ""});
+    registry.getSampleValue(
+        "aws_elb_request_count_average",
+        new String[] {"job", "instance"},
+        new String[] {"aws_elb", ""});
 
-
-    Mockito.verify(cloudWatchClient).listMetrics((ListMetricsRequest) argThat(
-            new ListMetricsRequestMatcher()
-                    .RecentlyActive(null).
-                    Namespace("AWS/ELB").
-                    MetricName("RequestCount").
-                    Dimensions("AvailabilityZone", "LoadBalancerName")
-    ));
+    Mockito.verify(cloudWatchClient)
+        .listMetrics(
+            (ListMetricsRequest)
+                argThat(
+                    new ListMetricsRequestMatcher()
+                        .RecentlyActive(null)
+                            .Namespace("AWS/ELB")
+                            .MetricName("RequestCount")
+                            .Dimensions("AvailabilityZone", "LoadBalancerName")));
   }
 
   @Test
@@ -695,11 +1811,15 @@ public class CloudWatchCollectorTest {
     String buildVersion = properties.getProperty("BuildVersion");
     String releaseDate = properties.getProperty("ReleaseDate");
 
-    assertEquals(1L,
-            registry.getSampleValue("cloudwatch_exporter_build_info",
-                    new String[]{"build_version", "release_date"},
-                    new String[]{buildVersion != null ? buildVersion: "unknown",
-                            releaseDate != null ? releaseDate: "unknown"}),
-            .00001);
+    assertEquals(
+        1L,
+        registry.getSampleValue(
+            "cloudwatch_exporter_build_info",
+            new String[] {"build_version", "release_date"},
+            new String[] {
+              buildVersion != null ? buildVersion : "unknown",
+              releaseDate != null ? releaseDate : "unknown"
+            }),
+        .00001);
   }
 }

--- a/src/test/java/io/prometheus/cloudwatch/GetMetricDataGetterTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/GetMetricDataGetterTest.java
@@ -4,17 +4,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.Test;
 
 public class GetMetricDataGetterTest {
-    @Test
-    public void testPartition() {
-        List<Integer> originalList = List.copyOf(Collections.nCopies(28, 0));
-        List<List<Integer>> partitions = GetMetricDataDataGetter.partitionByMaxSize(originalList, 40);
-        for (List<Integer> p : partitions) {
-            assertTrue("partition must be smaller than 40", p.size() <= 40);
-            assertTrue("partition should not be empty", !p.isEmpty());
-        }
+  @Test
+  public void testPartition() {
+    List<Integer> originalList = List.copyOf(Collections.nCopies(28, 0));
+    List<List<Integer>> partitions = GetMetricDataDataGetter.partitionByMaxSize(originalList, 40);
+    for (List<Integer> p : partitions) {
+      assertTrue("partition must be smaller than 40", p.size() <= 40);
+      assertTrue("partition should not be empty", !p.isEmpty());
     }
+  }
 }

--- a/src/test/java/io/prometheus/cloudwatch/RequestsMatchers.java
+++ b/src/test/java/io/prometheus/cloudwatch/RequestsMatchers.java
@@ -20,347 +20,345 @@ import software.amazon.awssdk.services.resourcegroupstaggingapi.model.TagFilter;
 
 public class RequestsMatchers {
 
-    static class ListMetricsRequestMatcher extends BaseMatcher<ListMetricsRequest> {
-        String namespace;
-        String metricName;
-        String nextToken;
-        String recentlyActive;
-        List<DimensionFilter> dimensions = new ArrayList<DimensionFilter>();
+  static class ListMetricsRequestMatcher extends BaseMatcher<ListMetricsRequest> {
+    String namespace;
+    String metricName;
+    String nextToken;
+    String recentlyActive;
+    List<DimensionFilter> dimensions = new ArrayList<DimensionFilter>();
 
-        public ListMetricsRequestMatcher Namespace(String namespace) {
-            this.namespace = namespace;
-            return this;
-        }
-
-        public ListMetricsRequestMatcher MetricName(String metricName) {
-            this.metricName = metricName;
-            return this;
-        }
-
-        public ListMetricsRequestMatcher NextToken(String nextToken) {
-            this.nextToken = nextToken;
-            return this;
-        }
-
-        public ListMetricsRequestMatcher Dimensions(String... dimensions) {
-            this.dimensions = new ArrayList<DimensionFilter>();
-            for (int i = 0; i < dimensions.length; i++) {
-                this.dimensions.add(DimensionFilter.builder().name(dimensions[i]).build());
-            }
-            return this;
-        }
-
-        public ListMetricsRequestMatcher RecentlyActive(String recentlyActive) {
-            this.recentlyActive = recentlyActive;
-            return this;
-        }
-
-        public boolean matches(Object o) {
-            ListMetricsRequest request = (ListMetricsRequest) o;
-            if (request == null)
-                return false;
-            if (namespace != null && !namespace.equals(request.namespace())) {
-                return false;
-            }
-            if (metricName != null && !metricName.equals(request.metricName())) {
-                return false;
-            }
-            if (nextToken == null ^ request.nextToken() == null) {
-                return false;
-            }
-            if (nextToken != null && !nextToken.equals(request.nextToken())) {
-                return false;
-            }
-            if (!dimensions.equals(request.dimensions())) {
-                return false;
-            }
-            if (recentlyActive != null && !recentlyActive.equals(request.recentlyActive())) {
-                return false;
-            }
-            return true;
-        }
-
-        public void describeTo(Description description) {
-            description.appendText("list metrics request");
-        }
+    public ListMetricsRequestMatcher Namespace(String namespace) {
+      this.namespace = namespace;
+      return this;
     }
 
-    static class GetMetricStatisticsRequestMatcher extends BaseMatcher<GetMetricStatisticsRequest> {
-        String namespace;
-        String metricName;
-        List<Dimension> dimensions = new ArrayList<Dimension>();
-        Integer period;
-
-        public GetMetricStatisticsRequestMatcher Namespace(String namespace) {
-            this.namespace = namespace;
-            return this;
-        }
-
-        public GetMetricStatisticsRequestMatcher MetricName(String metricName) {
-            this.metricName = metricName;
-            return this;
-        }
-
-        public GetMetricStatisticsRequestMatcher Dimension(String name, String value) {
-            dimensions.add(Dimension.builder().name(name).value(value).build());
-            return this;
-        }
-
-        public GetMetricStatisticsRequestMatcher Period(int period) {
-            this.period = period;
-            return this;
-        }
-
-        public boolean matches(Object o) {
-            GetMetricStatisticsRequest request = (GetMetricStatisticsRequest) o;
-            if (request == null)
-                return false;
-            if (namespace != null && !namespace.equals(request.namespace())) {
-                return false;
-            }
-            if (metricName != null && !metricName.equals(request.metricName())) {
-                return false;
-            }
-            if (!dimensions.equals(request.dimensions())) {
-                return false;
-            }
-            if (period != null && !period.equals(request.period())) {
-                return false;
-            }
-            return true;
-        }
-
-        public void describeTo(Description description) {
-            description.appendText("get metrics statistics request");
-        }
+    public ListMetricsRequestMatcher MetricName(String metricName) {
+      this.metricName = metricName;
+      return this;
     }
 
-    static class GetResourcesRequestMatcher extends BaseMatcher<GetResourcesRequest> {
-        String paginationToken = "";
-        List<String> resourceTypeFilters = new ArrayList<String>();
-        List<TagFilter> tagFilters = new ArrayList<TagFilter>();
-
-        public GetResourcesRequestMatcher PaginationToken(String paginationToken) {
-            this.paginationToken = paginationToken;
-            return this;
-        }
-
-        public GetResourcesRequestMatcher ResourceTypeFilter(String resourceTypeFilter) {
-            resourceTypeFilters.add(resourceTypeFilter);
-            return this;
-        }
-
-        public GetResourcesRequestMatcher TagFilter(String key, List<String> values) {
-            tagFilters.add(TagFilter.builder().key(key).values(values).build());
-            return this;
-        }
-
-        public boolean matches(Object o) {
-            GetResourcesRequest request = (GetResourcesRequest) o;
-            if (request == null)
-                return false;
-            if (paginationToken == "" ^ request.paginationToken() == "") {
-                return false;
-            }
-            if (paginationToken != "" && !paginationToken.equals(request.paginationToken())) {
-                return false;
-            }
-            if (!resourceTypeFilters.equals(request.resourceTypeFilters())) {
-                return false;
-            }
-            if (!tagFilters.equals(request.tagFilters())) {
-                return false;
-            }
-            return true;
-        }
-
-        public void describeTo(Description description) {
-            description.appendText("get resources request");
-        }
+    public ListMetricsRequestMatcher NextToken(String nextToken) {
+      this.nextToken = nextToken;
+      return this;
     }
 
-    static class MetricMatcher extends BaseMatcher<Metric> {
-        String namespace;
-        String metricName;
-        List<Dimension> dimensions = new ArrayList<Dimension>();
-
-        public MetricMatcher Namespace(String namespace) {
-            this.namespace = namespace;
-            return this;
-        }
-
-        public MetricMatcher MetricName(String metricName) {
-            this.metricName = metricName;
-            return this;
-        }
-
-        public MetricMatcher Dimension(String name, String value) {
-            dimensions.add(Dimension.builder().name(name).value(value).build());
-            return this;
-        }
-
-        @Override
-        public boolean matches(Object o) {
-            Metric metric = (Metric) o;
-            if (metric == null)
-                return false;
-            if (namespace != null && !namespace.equals(metric.namespace())) {
-                return false;
-            }
-            if (metricName != null && !metricName.equals(metric.metricName())) {
-                return false;
-            }
-            if (!dimensions.equals(metric.dimensions())) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("Metric");
-            List<String> properties = new ArrayList<>();
-            if (namespace!=null){
-                properties.add(String.format("namespace=%s",namespace));
-            }
-            if (metricName!=null){
-                properties.add(String.format("metricName=%s",metricName));
-            }
-            String dimentions=dimensions.stream().map((d)->d.name()+":"+d.value()).collect(Collectors.joining(", "));
-            properties.add(String.format("dimentions=[%s]",dimentions));
-            description.appendValueList("(", ",", ")", properties);
-        }
+    public ListMetricsRequestMatcher Dimensions(String... dimensions) {
+      this.dimensions = new ArrayList<DimensionFilter>();
+      for (int i = 0; i < dimensions.length; i++) {
+        this.dimensions.add(DimensionFilter.builder().name(dimensions[i]).build());
+      }
+      return this;
     }
 
-    static class MetricStatMatcher extends BaseMatcher<MetricStat> {
-        MetricMatcher metricMatcher;
-        String stat;
-        Integer period;
-
-        public MetricStatMatcher metric(MetricMatcher metricMatcher) {
-            this.metricMatcher = metricMatcher;
-            return this;
-        }
-
-        public MetricStatMatcher Period(int period) {
-            this.period = period;
-            return this;
-        }
-
-        public MetricStatMatcher Stat(String stat){
-            this.stat = stat;
-            return this;
-        }
-
-        @Override
-        public boolean matches(Object o) {
-            MetricStat metricStat = (MetricStat) o;
-            if (metricStat == null)
-                return false;
-            if (period != null && !period.equals(metricStat.period())) {
-                return false;
-            }
-            if (metricMatcher != null && !metricMatcher.matches(metricStat.metric())) {
-                return false;
-            }
-            if (stat!=null && !stat.equals(metricStat.stat())){
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("A metric stat");
-            if (stat!=null){
-                description.appendText(String.format(" with stat %s",stat));
-            }
-            if (period!=null){
-                description.appendText(String.format(" with period %s",period));
-            }
-            if (metricMatcher!=null){
-                description.appendText(" with metric ");
-                metricMatcher.describeTo(description);
-            }
-        }
+    public ListMetricsRequestMatcher RecentlyActive(String recentlyActive) {
+      this.recentlyActive = recentlyActive;
+      return this;
     }
 
-    static class MetricDataQueryMatcher extends BaseMatcher<MetricDataQuery> {
-        String label;
-        MetricStatMatcher metricStat;
-
-        public MetricDataQueryMatcher Label(String label) {
-            this.label = label;
-            return this;
-        }
-
-        public MetricDataQueryMatcher MetricStat(MetricStatMatcher metricStat) {
-            this.metricStat = metricStat;
-            return this;
-        }
-
-        @Override
-        public boolean matches(Object o) {
-            MetricDataQuery query = (MetricDataQuery) o;
-            if (query == null)
-                return false;
-            if (label != null && !label.equals(query.label())) {
-                return false;
-            }
-            if (metricStat != null && !metricStat.matches(query.metricStat())) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("metric data query");
-            if (label != null) {
-                description.appendText(String.format(" with label '%s'",label));
-            }
-            if (metricStat!=null){
-                description.appendText(" with stat: ");
-                metricStat.describeTo(description);
-            }
-        }
+    public boolean matches(Object o) {
+      ListMetricsRequest request = (ListMetricsRequest) o;
+      if (request == null) return false;
+      if (namespace != null && !namespace.equals(request.namespace())) {
+        return false;
+      }
+      if (metricName != null && !metricName.equals(request.metricName())) {
+        return false;
+      }
+      if (nextToken == null ^ request.nextToken() == null) {
+        return false;
+      }
+      if (nextToken != null && !nextToken.equals(request.nextToken())) {
+        return false;
+      }
+      if (!dimensions.equals(request.dimensions())) {
+        return false;
+      }
+      if (recentlyActive != null && !recentlyActive.equals(request.recentlyActive())) {
+        return false;
+      }
+      return true;
     }
 
-    static class GetMetricDataRequestMatcher extends BaseMatcher<GetMetricDataRequest> {
-        List<MetricDataQueryMatcher> queries = new ArrayList<>();
-
-        public GetMetricDataRequestMatcher Query(MetricDataQueryMatcher query) {
-            this.queries.add(query);
-            return this;
-        }
-
-        private Matcher<Iterable<MetricDataQuery>> queriesMatcher() {
-            return Matchers.hasItems(queries.stream().toArray(MetricDataQueryMatcher[]::new));
-        }
-
-        @Override
-        public boolean matches(Object o) {
-            GetMetricDataRequest request = (GetMetricDataRequest) o;
-            if (request == null) {
-                return false;
-            }
-            if (!queries.isEmpty() && !queriesMatcher().matches(request.metricDataQueries())) {
-                return false;
-            } ;
-            return true;
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("a GetMetricDataRequest");
-            if (!queries.isEmpty()){
-                description.appendText("with queries:\n");
-                for (MetricDataQueryMatcher qmatcher:queries){
-                    description.appendText("\t- ");
-                    qmatcher.describeTo(description);
-                    description.appendText("\n");                
-                }
-            } 
-        }
+    public void describeTo(Description description) {
+      description.appendText("list metrics request");
     }
+  }
+
+  static class GetMetricStatisticsRequestMatcher extends BaseMatcher<GetMetricStatisticsRequest> {
+    String namespace;
+    String metricName;
+    List<Dimension> dimensions = new ArrayList<Dimension>();
+    Integer period;
+
+    public GetMetricStatisticsRequestMatcher Namespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    public GetMetricStatisticsRequestMatcher MetricName(String metricName) {
+      this.metricName = metricName;
+      return this;
+    }
+
+    public GetMetricStatisticsRequestMatcher Dimension(String name, String value) {
+      dimensions.add(Dimension.builder().name(name).value(value).build());
+      return this;
+    }
+
+    public GetMetricStatisticsRequestMatcher Period(int period) {
+      this.period = period;
+      return this;
+    }
+
+    public boolean matches(Object o) {
+      GetMetricStatisticsRequest request = (GetMetricStatisticsRequest) o;
+      if (request == null) return false;
+      if (namespace != null && !namespace.equals(request.namespace())) {
+        return false;
+      }
+      if (metricName != null && !metricName.equals(request.metricName())) {
+        return false;
+      }
+      if (!dimensions.equals(request.dimensions())) {
+        return false;
+      }
+      if (period != null && !period.equals(request.period())) {
+        return false;
+      }
+      return true;
+    }
+
+    public void describeTo(Description description) {
+      description.appendText("get metrics statistics request");
+    }
+  }
+
+  static class GetResourcesRequestMatcher extends BaseMatcher<GetResourcesRequest> {
+    String paginationToken = "";
+    List<String> resourceTypeFilters = new ArrayList<String>();
+    List<TagFilter> tagFilters = new ArrayList<TagFilter>();
+
+    public GetResourcesRequestMatcher PaginationToken(String paginationToken) {
+      this.paginationToken = paginationToken;
+      return this;
+    }
+
+    public GetResourcesRequestMatcher ResourceTypeFilter(String resourceTypeFilter) {
+      resourceTypeFilters.add(resourceTypeFilter);
+      return this;
+    }
+
+    public GetResourcesRequestMatcher TagFilter(String key, List<String> values) {
+      tagFilters.add(TagFilter.builder().key(key).values(values).build());
+      return this;
+    }
+
+    public boolean matches(Object o) {
+      GetResourcesRequest request = (GetResourcesRequest) o;
+      if (request == null) return false;
+      if (paginationToken == "" ^ request.paginationToken() == "") {
+        return false;
+      }
+      if (paginationToken != "" && !paginationToken.equals(request.paginationToken())) {
+        return false;
+      }
+      if (!resourceTypeFilters.equals(request.resourceTypeFilters())) {
+        return false;
+      }
+      if (!tagFilters.equals(request.tagFilters())) {
+        return false;
+      }
+      return true;
+    }
+
+    public void describeTo(Description description) {
+      description.appendText("get resources request");
+    }
+  }
+
+  static class MetricMatcher extends BaseMatcher<Metric> {
+    String namespace;
+    String metricName;
+    List<Dimension> dimensions = new ArrayList<Dimension>();
+
+    public MetricMatcher Namespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    public MetricMatcher MetricName(String metricName) {
+      this.metricName = metricName;
+      return this;
+    }
+
+    public MetricMatcher Dimension(String name, String value) {
+      dimensions.add(Dimension.builder().name(name).value(value).build());
+      return this;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      Metric metric = (Metric) o;
+      if (metric == null) return false;
+      if (namespace != null && !namespace.equals(metric.namespace())) {
+        return false;
+      }
+      if (metricName != null && !metricName.equals(metric.metricName())) {
+        return false;
+      }
+      if (!dimensions.equals(metric.dimensions())) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("Metric");
+      List<String> properties = new ArrayList<>();
+      if (namespace != null) {
+        properties.add(String.format("namespace=%s", namespace));
+      }
+      if (metricName != null) {
+        properties.add(String.format("metricName=%s", metricName));
+      }
+      String dimentions =
+          dimensions.stream()
+              .map((d) -> d.name() + ":" + d.value())
+              .collect(Collectors.joining(", "));
+      properties.add(String.format("dimentions=[%s]", dimentions));
+      description.appendValueList("(", ",", ")", properties);
+    }
+  }
+
+  static class MetricStatMatcher extends BaseMatcher<MetricStat> {
+    MetricMatcher metricMatcher;
+    String stat;
+    Integer period;
+
+    public MetricStatMatcher metric(MetricMatcher metricMatcher) {
+      this.metricMatcher = metricMatcher;
+      return this;
+    }
+
+    public MetricStatMatcher Period(int period) {
+      this.period = period;
+      return this;
+    }
+
+    public MetricStatMatcher Stat(String stat) {
+      this.stat = stat;
+      return this;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      MetricStat metricStat = (MetricStat) o;
+      if (metricStat == null) return false;
+      if (period != null && !period.equals(metricStat.period())) {
+        return false;
+      }
+      if (metricMatcher != null && !metricMatcher.matches(metricStat.metric())) {
+        return false;
+      }
+      if (stat != null && !stat.equals(metricStat.stat())) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("A metric stat");
+      if (stat != null) {
+        description.appendText(String.format(" with stat %s", stat));
+      }
+      if (period != null) {
+        description.appendText(String.format(" with period %s", period));
+      }
+      if (metricMatcher != null) {
+        description.appendText(" with metric ");
+        metricMatcher.describeTo(description);
+      }
+    }
+  }
+
+  static class MetricDataQueryMatcher extends BaseMatcher<MetricDataQuery> {
+    String label;
+    MetricStatMatcher metricStat;
+
+    public MetricDataQueryMatcher Label(String label) {
+      this.label = label;
+      return this;
+    }
+
+    public MetricDataQueryMatcher MetricStat(MetricStatMatcher metricStat) {
+      this.metricStat = metricStat;
+      return this;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      MetricDataQuery query = (MetricDataQuery) o;
+      if (query == null) return false;
+      if (label != null && !label.equals(query.label())) {
+        return false;
+      }
+      if (metricStat != null && !metricStat.matches(query.metricStat())) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("metric data query");
+      if (label != null) {
+        description.appendText(String.format(" with label '%s'", label));
+      }
+      if (metricStat != null) {
+        description.appendText(" with stat: ");
+        metricStat.describeTo(description);
+      }
+    }
+  }
+
+  static class GetMetricDataRequestMatcher extends BaseMatcher<GetMetricDataRequest> {
+    List<MetricDataQueryMatcher> queries = new ArrayList<>();
+
+    public GetMetricDataRequestMatcher Query(MetricDataQueryMatcher query) {
+      this.queries.add(query);
+      return this;
+    }
+
+    private Matcher<Iterable<MetricDataQuery>> queriesMatcher() {
+      return Matchers.hasItems(queries.stream().toArray(MetricDataQueryMatcher[]::new));
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      GetMetricDataRequest request = (GetMetricDataRequest) o;
+      if (request == null) {
+        return false;
+      }
+      if (!queries.isEmpty() && !queriesMatcher().matches(request.metricDataQueries())) {
+        return false;
+      }
+      ;
+      return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("a GetMetricDataRequest");
+      if (!queries.isEmpty()) {
+        description.appendText("with queries:\n");
+        for (MetricDataQueryMatcher qmatcher : queries) {
+          description.appendText("\t- ");
+          qmatcher.describeTo(description);
+          description.appendText("\n");
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Resolves #417 :-) 
Note: this requires JDK > 11

The first commit is adding a maven plugin that can check and auto-fix formatting + adds CircleCI step that fails if somehow the developer forgot to format. You can see the CircleCI failure (as the code is not formatted).

The second commit is after applying the plugin format.