### PR TITLE
Update maven dependencies (jetty 10->11)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/circleci-java
     docker:
-      - image: circleci/openjdk:17-jdk-buster
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
@@ -26,7 +26,7 @@ jobs:
       - run: mvn package
   publish_image:
     docker:
-      - image: circleci/openjdk:17-jdk-buster
+      - image: cimg/openjdk:17.0
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64
@@ -71,7 +71,7 @@ jobs:
       - run: docker images
   build_image:
     docker:
-      - image: circleci/openjdk:17-jdk-buster
+      - image: cimg/openjdk:17.0
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64

--- a/pom.xml
+++ b/pom.xml
@@ -41,32 +41,40 @@
       <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.releaseDate>${maven.build.timestamp}</project.releaseDate>
+    <software.amazon.awssdk.version>2.17.170</software.amazon.awssdk.version>
+    <io.prometheus.version>0.15.0</io.prometheus.version>
+  </properties>
   <dependencies>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>cloudwatch</artifactId>
-      <version>2.17.170</version>
+      <version>${software.amazon.awssdk.version}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.17.170</version>
+      <version>${software.amazon.awssdk.version}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>resourcegroupstaggingapi</artifactId>
-      <version>2.17.170</version>
+      <version>${software.amazon.awssdk.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.13</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.32</version>
+      <version>1.7.36</version>
     </dependency>
     <!--
       Older versions of jackson-databind have remote code execution vulnerabilities
@@ -83,27 +91,27 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.29</version>
+      <version>1.30</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.14.1</version>
+      <version>${io.prometheus.version}</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_servlet</artifactId>
-      <version>0.14.1</version>
+      <artifactId>simpleclient_servlet_jakarta</artifactId>
+      <version>${io.prometheus.version}</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
-      <version>0.14.1</version>
+      <version>${io.prometheus.version}</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>10.0.8</version>
+        <version>11.0.9</version>
     </dependency>
 
     <dependency>
@@ -138,10 +146,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.10.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
       </plugin>
       <!-- Build a full jar with dependencies -->
@@ -233,13 +240,6 @@
     </plugin>
     </plugins>
   </build>
-
-  <properties>
-    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.releaseDate>${maven.build.timestamp}</project.releaseDate>
-  </properties>
 
   <profiles>
       <profile>

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -1,10 +1,10 @@
 package io.prometheus.cloudwatch;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class DynamicReloadServlet extends HttpServlet {
   private static final long serialVersionUID = 9078784531819993933L;

--- a/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
@@ -38,13 +39,17 @@ class GetMetricDataDataGetter implements DataGetter {
   }
 
   private static String dimentionsToKey(List<Dimension> dimentions) {
-    return String.join(",", dimentions.stream().map(d -> dimentionToString(d)).sorted().toList());
+    return dimentions.stream()
+        .map(GetMetricDataDataGetter::dimentionToString)
+        .sorted()
+        .collect(Collectors.joining(","));
   }
 
   private List<String> buildStatsList(MetricRule rule) {
     List<String> stats = new ArrayList<>();
     if (rule.awsStatistics != null) {
-      stats.addAll(rule.awsStatistics.stream().map(s -> s.toString()).toList());
+      stats.addAll(
+          rule.awsStatistics.stream().map(Statistic::toString).collect(Collectors.toList()));
     }
     if (rule.awsExtendedStatistics != null) {
       stats.addAll(rule.awsExtendedStatistics);

--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -1,10 +1,10 @@
 package io.prometheus.cloudwatch;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class HealthServlet extends HttpServlet {
   private static final long serialVersionUID = 5543118274931292897L;

--- a/src/main/java/io/prometheus/cloudwatch/HomePageServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HomePageServlet.java
@@ -1,10 +1,10 @@
 package io.prometheus.cloudwatch;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class HomePageServlet extends HttpServlet {
   private static final long serialVersionUID = 3239704246954810347L;

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -1,7 +1,7 @@
 package io.prometheus.cloudwatch;
 
-import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
+import io.prometheus.client.servlet.jakarta.exporter.MetricsServlet;
 import java.io.FileReader;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;


### PR DESCRIPTION
Fixes #390 ... + 
1. Moving repeated versions to maven properties (aws, prometheus)
2. Updating prometheus - 0.14.1 --> 0.15.0
3. Updating jetty - 10.0.8 --> 11.0.9
4. commons-coden 1.13 --> 1.15
5. Updating maven compiler plugin and release level.
6. Updated CircleCI image to `cimg/openjdk:17.0.3` (instead of deprecated openjdk image)