### PR TITLE
Log warning in case of listDimensions returns empty list

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -424,7 +424,6 @@ public class CloudWatchCollector extends Collector implements Describable {
         }
       }
     }
-
     return result;
   }
 
@@ -468,7 +467,12 @@ public class CloudWatchCollector extends Collector implements Describable {
       }
       nextToken = response.nextToken();
     } while (nextToken != null);
-
+    if (dimensions.isEmpty()) {
+      LOGGER.warning(
+          String.format(
+              "(listDimensions) ignoring metric %s:%s due to dimensions mismatch",
+              rule.awsNamespace, rule.awsMetricName));
+    }
     return dimensions;
   }
 


### PR DESCRIPTION
Relates to #432  - print warning in case dimensions is empty. 
Otherwise - it's hard to understand that configuration is wrong.

I wonder though if there is any scenario where the case of empty dimensions is actually okay. 
If there are - then this warning may be spamming and wrong.