### PR TITLE
Github Issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,54 @@
+---
+name: 'Report a bug'
+about: Report a bug 🪲
+title: "[bug]: bug title here"
+labels: bug
+assignees: ''
+
+---
+
+### What did you do
+Please provide steps for us to reproduce this issue? Example for config file are very welcomed!
+
+### What did you expect to see?
+
+
+### What did you see instead? Under which circumstances?
+
+
+### Are you currently working around this issue?
+How are you currently solving this problem?
+
+### Additional context
+Anything else we should know?
+
+### Attachments
+If you think you might have additional information that you'd like to include via an attachment, please do - we'll take a look. (Remember to remove any personally-identifiable information.)
+
+### Environment
+* Exporter version: `X.X.X`
+* Operating system & architecture: `XX` <!-- `uname -a` or equivalent -->
+* Running in containers? y/n
+* Using the official image? y/n
+
+
+<!-- Remember to clear private information -->
+### Exporter configuration file
+<details>
+<summary>expand</summary>
+
+```yaml
+
+```
+</details>
+
+
+### Logs
+<!-- Remember to clear private information -->
+<details>
+<summary>expand</summary>
+
+```
+(paste log lines here)
+```
+</details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Prometheus community channels
+    url: https://prometheus.io/community
+    about: For general prometheus questions ❓❓ 
+  - name: Cloudwatch Service quotas
+    url: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
+    about: Read about Cloudwatch quotas

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -1,0 +1,20 @@
+---
+name: 'Suggest a feature'
+about: Suggest an idea to make the tool better! 🌟
+title: "[request]: describe request here"
+labels: enhancement
+assignees: ''
+
+---
+# Proposal
+###  Use case. Why is this important?
+
+<!-- Please describe how this enhancement would improve your user experience -->
+
+<!-- If changed configuration required -->
+### How do you think the new configuration should look like?
+
+Example:
+```yaml
+
+```


### PR DESCRIPTION
Hi,

I want to address the problem of issues being open with insufficient information.
I suggest splitting our issues into three kinds:
- [x] bug report
- [x] Feature request ("enhancement")
- [x] ~support (still to do)~

I think using the [Github issue template](https://docs.github.com/en/enterprise-server@3.1/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) can help minimize missing information.

The template picker would look +- like this upon opening a new issue:
<img width="734" alt="image" src="https://user-images.githubusercontent.com/2962963/177494091-4f842801-2b9d-4863-92b9-701c84d586c0.png">

As always - feel free to suggest more / fewer fields or alternative wording.

Thanks!