### PR TITLE
list-metrics-warnings made configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/
 set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
 use_get_metric_data | Optional. Boolean (experimental) Use GetMetricData API to get metrics instead of GetMetricStatistics.
 list_metrics_cache_ttl | Optional. Number of seconds to cache the result of calling the ListMetrics API. Defaults to 0 (no cache). Can be set globally and per metric.
+warn_on_empty_list_dimensions | Optional. Boolean Emit warning if the exporter cannot determine what metrics to request
 
 
 The above config will export time series such as

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -170,6 +170,11 @@ public class CloudWatchCollector extends Collector implements Describable {
           Duration.ofSeconds(((Number) config.get("list_metrics_cache_ttl")).intValue());
     }
 
+    boolean defaultWarnOnMissingDimensions = false;
+    if (config.containsKey("warn_on_empty_list_dimensions")) {
+      defaultWarnOnMissingDimensions = (Boolean) config.get("warn_on_empty_list_dimensions");
+    }
+
     String region = (String) config.get("region");
 
     if (cloudWatchClient == null) {
@@ -274,6 +279,12 @@ public class CloudWatchCollector extends Collector implements Describable {
         rule.useGetMetricData = (Boolean) yamlMetricRule.get("use_get_metric_data");
       } else {
         rule.useGetMetricData = defaultUseGetMetricData;
+      }
+      if (yamlMetricRule.containsKey("warn_on_empty_list_dimensions")) {
+        rule.warnOnEmptyListDimensions =
+            (Boolean) yamlMetricRule.get("warn_on_empty_list_dimensions");
+      } else {
+        rule.warnOnEmptyListDimensions = defaultWarnOnMissingDimensions;
       }
 
       if (yamlMetricRule.containsKey("aws_tag_select")) {

--- a/src/main/java/io/prometheus/cloudwatch/DefaultDimensionSource.java
+++ b/src/main/java/io/prometheus/cloudwatch/DefaultDimensionSource.java
@@ -102,7 +102,7 @@ final class DefaultDimensionSource implements DimensionSource {
       }
       nextToken = response.nextToken();
     } while (nextToken != null);
-    if (dimensions.isEmpty()) {
+    if (rule.warnOnEmptyListDimensions && dimensions.isEmpty()) {
       LOGGER.warning(
           String.format(
               "(listDimensions) ignoring metric %s:%s due to dimensions mismatch",

--- a/src/main/java/io/prometheus/cloudwatch/MetricRule.java
+++ b/src/main/java/io/prometheus/cloudwatch/MetricRule.java
@@ -22,6 +22,7 @@ class MetricRule {
   boolean cloudwatchTimestamp;
   boolean useGetMetricData;
   Duration listMetricsCacheTtl;
+  boolean warnOnEmptyListDimensions;
 
   @Override
   public boolean equals(Object o) {


### PR DESCRIPTION
Addresses #442
- [x] Warnings for list metrics is now configurable globally / per metric.
- [x] ~(still WIP) Added explanation in README  on how exporter determines which dimensions to scrape.~ (will create a different PR)