### PR TITLE
Disallow TRACE HTTP method

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/DisallowHttpMethods.java
+++ b/src/main/java/io/prometheus/cloudwatch/DisallowHttpMethods.java
@@ -1,0 +1,25 @@
+package io.prometheus.cloudwatch;
+
+import java.util.EnumSet;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+
+class DisallowHttpMethods implements HttpConfiguration.Customizer {
+  private final EnumSet<HttpMethod> disallowedMethods;
+
+  public DisallowHttpMethods(EnumSet<HttpMethod> disallowedMethods) {
+    this.disallowedMethods = disallowedMethods;
+  }
+
+  @Override
+  public void customize(Connector connector, HttpConfiguration channelConfig, Request request) {
+    HttpMethod httpMethod = HttpMethod.fromString(request.getMethod());
+    if (disallowedMethods.contains(httpMethod)) {
+      request.setHandled(true);
+      request.getResponse().setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);
+    }
+  }
+}

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -3,7 +3,12 @@ package io.prometheus.cloudwatch;
 import io.prometheus.client.hotspot.DefaultExports;
 import io.prometheus.client.servlet.jakarta.exporter.MetricsServlet;
 import java.io.FileReader;
+import java.util.EnumSet;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -28,7 +33,13 @@ public class WebServer {
     ReloadSignalHandler.start(collector);
 
     int port = Integer.parseInt(args[0]);
-    Server server = new Server(port);
+    Server server = new Server();
+    HttpConfiguration httpConfig = new HttpConfiguration();
+    httpConfig.addCustomizer(new DisallowHttpMethods(EnumSet.of(HttpMethod.TRACE)));
+    ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+    connector.setPort(port);
+    server.addConnector(connector);
+
     ServletContextHandler context = new ServletContextHandler();
     context.setContextPath("/");
     server.setHandler(context);


### PR DESCRIPTION
Even though I believe there is no actual risk of [Cross-Site Tracing][xst] attacks in cloudwatch-exporter, disallowing
the `TRACE` HTTP method in Jetty reduces attack surface and makes security scans happier.

(Non-embedded) Jetty disables `TRACE` [in the default configuration][jetty-webapp] by forcing requests using that method be authenticated. I thought using a customizer would be cleaner and, as a bonus, would also be able to return a more accurate HTTP status code (405 Method Not Allowed).

[xst]: https://owasp.org/www-community/attacks/Cross_Site_Tracing
[jetty-webapp]: https://github.com/eclipse/jetty.project/blob/jetty-11.0.11/jetty-webapp/src/main/config/etc/webdefault.xml#L423-L440