### PR TITLE
Cache calls to ListMetrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ range_seconds | Optional. How far back to request data for. Useful for cases suc
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
 set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
 use_get_metric_data | Optional. Boolean (experimental) Use GetMetricData API to get metrics instead of GetMetricStatistics.
-list_metrics_cache_ttl_seconds | Optional. Number of seconds to cache the result of calling the ListMetrics API. Defaults to 0 (no cache). Can be set globally and per metric.
+list_metrics_cache_ttl | Optional. Number of seconds to cache the result of calling the ListMetrics API. Defaults to 0 (no cache). Can be set globally and per metric.
 
 
 The above config will export time series such as

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ range_seconds | Optional. How far back to request data for. Useful for cases suc
 period_seconds | Optional. [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) to request the metric for. Only the most recent data point is used. Defaults to 60s. Can be set globally and per metric.
 set_timestamp | Optional. Boolean for whether to set the Prometheus metric timestamp as the original Cloudwatch timestamp. For some metrics which are updated very infrequently (such as S3/BucketSize), Prometheus may refuse to scrape them if this is set to true (see #100). Defaults to true. Can be set globally and per metric.
 use_get_metric_data | Optional. Boolean (experimental) Use GetMetricData API to get metrics instead of GetMetricStatistics.
+list_metrics_cache_ttl_seconds | Optional. Number of seconds to cache the result of calling the ListMetrics API. Defaults to 0 (no cache). Can be set globally and per metric.
 
 
 The above config will export time series such as

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>jetty-servlet</artifactId>
       <version>11.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>3.1.1</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/io/prometheus/cloudwatch/CachingDimensionSource.java
+++ b/src/main/java/io/prometheus/cloudwatch/CachingDimensionSource.java
@@ -1,0 +1,132 @@
+package io.prometheus.cloudwatch;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+final class CachingDimensionSource implements DimensionSource {
+
+  private static final int MAX_ENTRIES = 500;
+  private final DimensionSource delegate;
+  private final Cache<DimensionCacheKey, DimensionData> cache;
+
+  CachingDimensionSource(DimensionSource delegate, Cache<DimensionCacheKey, DimensionData> cache) {
+    this.delegate = delegate;
+    this.cache = cache;
+  }
+
+  /**
+   * Create a new DimensionSource that will cache the results from another {@link DimensionSource}
+   *
+   * @param source
+   * @param config - config used to configure the expiry (ttl) for entries in the cache
+   * @return a new CachingDimensionSource
+   */
+  static DimensionSource create(DimensionSource source, DimensionCacheConfig config) {
+    Cache<DimensionCacheKey, DimensionData> cache =
+        Caffeine.newBuilder()
+            .maximumSize(MAX_ENTRIES)
+            .expireAfter(new DimensionExpiry(config.defaultExpiry, config.metricConfig))
+            .build();
+
+    return new CachingDimensionSource(source, cache);
+  }
+
+  @Override
+  public DimensionData getDimensions(MetricRule rule, List<String> tagBasedResourceIds) {
+    DimensionData cachedDimensions =
+        this.cache.getIfPresent(new DimensionCacheKey(rule, tagBasedResourceIds));
+    if (cachedDimensions != null) {
+      return cachedDimensions;
+    }
+    DimensionData dimensions = delegate.getDimensions(rule, tagBasedResourceIds);
+    this.cache.put(new DimensionCacheKey(rule, tagBasedResourceIds), dimensions);
+    return dimensions;
+  }
+
+  static class DimensionExpiry implements Expiry<DimensionCacheKey, DimensionData> {
+
+    private final Duration defaultExpiry;
+    private final Map<MetricRule, Duration> durationMap;
+
+    public DimensionExpiry(Duration defaultExpiry, List<MetricRule> expiryOverrides) {
+      this.defaultExpiry = defaultExpiry;
+      this.durationMap =
+          expiryOverrides.stream()
+              .collect(Collectors.toMap(Function.identity(), dcp -> dcp.listMetricsCacheTtl));
+    }
+
+    @Override
+    public long expireAfterCreate(DimensionCacheKey key, DimensionData value, long currentTime) {
+      return durationMap.getOrDefault(key.rule, this.defaultExpiry).toNanos();
+    }
+
+    @Override
+    public long expireAfterUpdate(
+        DimensionCacheKey key, DimensionData value, long currentTime, long currentDuration) {
+      return currentDuration;
+    }
+
+    @Override
+    public long expireAfterRead(
+        DimensionCacheKey key, DimensionData value, long currentTime, long currentDuration) {
+      return currentDuration;
+    }
+  }
+
+  static class DimensionCacheConfig {
+    final Duration defaultExpiry;
+    final List<MetricRule> metricConfig = new ArrayList<>();
+
+    DimensionCacheConfig(Duration defaultExpiry) {
+      this.defaultExpiry = defaultExpiry;
+    }
+
+    /**
+     * Add a MetricRule to be used to configure a custom TTL using the value from {@link
+     * MetricRule#listMetricsCacheTtl} to override the default expiry
+     *
+     * @param metricRule
+     * @return this
+     */
+    DimensionCacheConfig addOverride(MetricRule metricRule) {
+      this.metricConfig.add(metricRule);
+      return this;
+    }
+  }
+
+  static class DimensionCacheKey {
+    private final MetricRule rule;
+    private final List<String> tagBasedResourceIds;
+
+    DimensionCacheKey(MetricRule rule, List<String> tagBasedResourceIds) {
+      this.rule = rule;
+      this.tagBasedResourceIds = tagBasedResourceIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      DimensionCacheKey that = (DimensionCacheKey) o;
+
+      if (!Objects.equals(rule, that.rule)) return false;
+      return Objects.equals(tagBasedResourceIds, that.tagBasedResourceIds);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = rule != null ? rule.hashCode() : 0;
+      result = 31 * result + (tagBasedResourceIds != null ? tagBasedResourceIds.hashCode() : 0);
+      return result;
+    }
+  }
+}

--- a/src/main/java/io/prometheus/cloudwatch/CachingDimensionSource.java
+++ b/src/main/java/io/prometheus/cloudwatch/CachingDimensionSource.java
@@ -13,14 +13,8 @@ import java.util.stream.Collectors;
 
 final class CachingDimensionSource implements DimensionSource {
 
-  private static final int MAX_ENTRIES = 500;
   private final DimensionSource delegate;
   private final Cache<DimensionCacheKey, DimensionData> cache;
-
-  CachingDimensionSource(DimensionSource delegate, Cache<DimensionCacheKey, DimensionData> cache) {
-    this.delegate = delegate;
-    this.cache = cache;
-  }
 
   /**
    * Create a new DimensionSource that will cache the results from another {@link DimensionSource}
@@ -29,14 +23,12 @@ final class CachingDimensionSource implements DimensionSource {
    * @param config - config used to configure the expiry (ttl) for entries in the cache
    * @return a new CachingDimensionSource
    */
-  static DimensionSource create(DimensionSource source, DimensionCacheConfig config) {
-    Cache<DimensionCacheKey, DimensionData> cache =
+  CachingDimensionSource(DimensionSource source, DimensionCacheConfig config) {
+    this.delegate = source;
+    this.cache =
         Caffeine.newBuilder()
-            .maximumSize(MAX_ENTRIES)
             .expireAfter(new DimensionExpiry(config.defaultExpiry, config.metricConfig))
             .build();
-
-    return new CachingDimensionSource(source, cache);
   }
 
   @Override

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -309,7 +309,7 @@ public class CloudWatchCollector extends Collector implements Describable {
     DimensionSource dimensionSource =
         new DefaultDimensionSource(cloudWatchClient, cloudwatchRequests);
     if (defaultMetricCacheSeconds.toSeconds() > 0 || !metricCacheConfig.metricConfig.isEmpty()) {
-      dimensionSource = CachingDimensionSource.create(dimensionSource, metricCacheConfig);
+      dimensionSource = new CachingDimensionSource(dimensionSource, metricCacheConfig);
     }
 
     loadConfig(rules, cloudWatchClient, taggingClient, dimensionSource);

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -1,5 +1,7 @@
 package io.prometheus.cloudwatch;
 
+import static io.prometheus.cloudwatch.CachingDimensionSource.DimensionCacheConfig;
+
 import io.prometheus.client.Collector;
 import io.prometheus.client.Collector.Describable;
 import io.prometheus.client.Counter;
@@ -7,6 +9,7 @@ import io.prometheus.cloudwatch.DataGetter.MetricRuleData;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,17 +21,12 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import org.yaml.snakeyaml.Yaml;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClientBuilder;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
-import software.amazon.awssdk.services.cloudwatch.model.DimensionFilter;
-import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest;
-import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse;
-import software.amazon.awssdk.services.cloudwatch.model.Metric;
 import software.amazon.awssdk.services.cloudwatch.model.Statistic;
 import software.amazon.awssdk.services.resourcegroupstaggingapi.ResourceGroupsTaggingApiClient;
 import software.amazon.awssdk.services.resourcegroupstaggingapi.ResourceGroupsTaggingApiClientBuilder;
@@ -48,31 +46,16 @@ public class CloudWatchCollector extends Collector implements Describable {
     ArrayList<MetricRule> rules;
     CloudWatchClient cloudWatchClient;
     ResourceGroupsTaggingApiClient taggingClient;
+    DimensionSource dimensionSource;
 
     public ActiveConfig(ActiveConfig cfg) {
       this.rules = new ArrayList<>(cfg.rules);
       this.cloudWatchClient = cfg.cloudWatchClient;
       this.taggingClient = cfg.taggingClient;
+      this.dimensionSource = cfg.dimensionSource;
     }
 
     public ActiveConfig() {}
-  }
-
-  static class MetricRule {
-    String awsNamespace;
-    String awsMetricName;
-    int periodSeconds;
-    int rangeSeconds;
-    int delaySeconds;
-    List<Statistic> awsStatistics;
-    List<String> awsExtendedStatistics;
-    List<String> awsDimensions;
-    Map<String, List<String>> awsDimensionSelect;
-    Map<String, List<String>> awsDimensionSelectRegex;
-    AWSTagSelect awsTagSelect;
-    String help;
-    boolean cloudwatchTimestamp;
-    boolean useGetMetricData;
   }
 
   static class AWSTagSelect {
@@ -181,6 +164,12 @@ public class CloudWatchCollector extends Collector implements Describable {
       defaultUseGetMetricData = (Boolean) config.get("use_get_metric_data");
     }
 
+    Duration defaultMetricCacheSeconds = Duration.ofSeconds(0);
+    if (config.containsKey("list_metrics_cache_ttl")) {
+      defaultMetricCacheSeconds =
+          Duration.ofSeconds(((Number) config.get("list_metrics_cache_ttl")).intValue());
+    }
+
     String region = (String) config.get("region");
 
     if (cloudWatchClient == null) {
@@ -214,6 +203,7 @@ public class CloudWatchCollector extends Collector implements Describable {
       throw new IllegalArgumentException("Must provide metrics");
     }
 
+    DimensionCacheConfig metricCacheConfig = new DimensionCacheConfig(defaultMetricCacheSeconds);
     ArrayList<MetricRule> rules = new ArrayList<>();
 
     for (Object ruleObject : (List<Map<String, Object>>) config.get("metrics")) {
@@ -306,19 +296,35 @@ public class CloudWatchCollector extends Collector implements Describable {
               (Map<String, List<String>>) yamlAwsTagSelect.get("tag_selections");
         }
       }
+
+      if (yamlMetricRule.containsKey("list_metrics_cache_ttl")) {
+        rule.listMetricsCacheTtl =
+            Duration.ofSeconds(((Number) yamlMetricRule.get("list_metrics_cache_ttl")).intValue());
+        metricCacheConfig.addOverride(rule);
+      } else {
+        rule.listMetricsCacheTtl = defaultMetricCacheSeconds;
+      }
     }
 
-    loadConfig(rules, cloudWatchClient, taggingClient);
+    DimensionSource dimensionSource =
+        new DefaultDimensionSource(cloudWatchClient, cloudwatchRequests);
+    if (defaultMetricCacheSeconds.toSeconds() > 0 || !metricCacheConfig.metricConfig.isEmpty()) {
+      dimensionSource = CachingDimensionSource.create(dimensionSource, metricCacheConfig);
+    }
+
+    loadConfig(rules, cloudWatchClient, taggingClient, dimensionSource);
   }
 
   private void loadConfig(
       ArrayList<MetricRule> rules,
       CloudWatchClient cloudWatchClient,
-      ResourceGroupsTaggingApiClient taggingClient) {
+      ResourceGroupsTaggingApiClient taggingClient,
+      DimensionSource dimensionSource) {
     synchronized (activeConfig) {
       activeConfig.cloudWatchClient = cloudWatchClient;
       activeConfig.taggingClient = taggingClient;
       activeConfig.rules = rules;
+      activeConfig.dimensionSource = dimensionSource;
     }
   }
 
@@ -344,7 +350,7 @@ public class CloudWatchCollector extends Collector implements Describable {
 
     List<TagFilter> tagFilters = new ArrayList<>();
     if (rule.awsTagSelect.tagSelections != null) {
-      for (Map.Entry<String, List<String>> entry : rule.awsTagSelect.tagSelections.entrySet()) {
+      for (Entry<String, List<String>> entry : rule.awsTagSelect.tagSelections.entrySet()) {
         tagFilters.add(TagFilter.builder().key(entry.getKey()).values(entry.getValue()).build());
       }
     }
@@ -375,181 +381,6 @@ public class CloudWatchCollector extends Collector implements Describable {
       resourceIds.add(extractResourceIdFromArn(resourceTagMapping.resourceARN()));
     }
     return resourceIds;
-  }
-
-  private String extractResourceIdFromArn(String arn) {
-    // ARN parsing is based on
-    // https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-    String[] arnArray = arn.split(":");
-    String resourceId = arnArray[arnArray.length - 1];
-    if (resourceId.contains("/")) {
-      String[] resourceArray = resourceId.split("/", 2);
-      resourceId = resourceArray[resourceArray.length - 1];
-    }
-    return resourceId;
-  }
-
-  private List<List<Dimension>> getDimensions(
-      MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
-    if (rule.awsDimensions != null
-        && rule.awsDimensionSelect != null
-        && !rule.awsDimensions.isEmpty()
-        && rule.awsDimensions.size() == rule.awsDimensionSelect.size()
-        && rule.awsDimensionSelect.keySet().containsAll(rule.awsDimensions)
-        && rule.awsTagSelect == null) {
-      // The full list of dimensions is known so no need to request it from cloudwatch.
-      return permuteDimensions(rule.awsDimensions, rule.awsDimensionSelect);
-    } else {
-      return listDimensions(rule, tagBasedResourceIds, cloudWatchClient);
-    }
-  }
-
-  private List<List<Dimension>> permuteDimensions(
-      List<String> dimensions, Map<String, List<String>> dimensionValues) {
-    ArrayList<List<Dimension>> result = new ArrayList<>();
-
-    if (dimensions.isEmpty()) {
-      result.add(new ArrayList<>());
-    } else {
-      List<String> dimensionsCopy = new ArrayList<>(dimensions);
-      String dimensionName = dimensionsCopy.remove(dimensionsCopy.size() - 1);
-      for (List<Dimension> permutation : permuteDimensions(dimensionsCopy, dimensionValues)) {
-        for (String dimensionValue : dimensionValues.get(dimensionName)) {
-          Dimension.Builder dimensionBuilder = Dimension.builder();
-          dimensionBuilder.value(dimensionValue);
-          dimensionBuilder.name(dimensionName);
-          ArrayList<Dimension> permutationCopy = new ArrayList<>(permutation);
-          permutationCopy.add(dimensionBuilder.build());
-          result.add(permutationCopy);
-        }
-      }
-    }
-    return result;
-  }
-
-  private List<List<Dimension>> listDimensions(
-      MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
-    List<List<Dimension>> dimensions = new ArrayList<>();
-    if (rule.awsDimensions == null) {
-      dimensions.add(new ArrayList<>());
-      return dimensions;
-    }
-
-    ListMetricsRequest.Builder requestBuilder = ListMetricsRequest.builder();
-    requestBuilder.namespace(rule.awsNamespace);
-    requestBuilder.metricName(rule.awsMetricName);
-
-    // 10800 seconds is 3 hours, this setting causes metrics older than 3 hours to not be listed
-    if (rule.rangeSeconds < 10800) {
-      requestBuilder.recentlyActive("PT3H");
-    }
-
-    List<DimensionFilter> dimensionFilters = new ArrayList<>();
-    for (String dimension : rule.awsDimensions) {
-      dimensionFilters.add(DimensionFilter.builder().name(dimension).build());
-    }
-    requestBuilder.dimensions(dimensionFilters);
-
-    String nextToken = null;
-    do {
-      requestBuilder.nextToken(nextToken);
-      ListMetricsResponse response = cloudWatchClient.listMetrics(requestBuilder.build());
-      cloudwatchRequests.labels("listMetrics", rule.awsNamespace).inc();
-      for (Metric metric : response.metrics()) {
-        if (metric.dimensions().size() != dimensionFilters.size()) {
-          // AWS returns all the metrics with dimensions beyond the ones we ask for,
-          // so filter them out.
-          continue;
-        }
-        if (useMetric(rule, tagBasedResourceIds, metric)) {
-          dimensions.add(metric.dimensions());
-        }
-      }
-      nextToken = response.nextToken();
-    } while (nextToken != null);
-    if (dimensions.isEmpty()) {
-      LOGGER.warning(
-          String.format(
-              "(listDimensions) ignoring metric %s:%s due to dimensions mismatch",
-              rule.awsNamespace, rule.awsMetricName));
-    }
-    return dimensions;
-  }
-
-  /**
-   * Check if a metric should be used according to `aws_dimension_select`,
-   * `aws_dimension_select_regex` and dynamic `aws_tag_select`
-   */
-  private boolean useMetric(MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
-    if (rule.awsDimensionSelect != null && !metricsIsInAwsDimensionSelect(rule, metric)) {
-      return false;
-    }
-    if (rule.awsDimensionSelectRegex != null && !metricIsInAwsDimensionSelectRegex(rule, metric)) {
-      return false;
-    }
-    if (rule.awsTagSelect != null && !metricIsInAwsTagSelect(rule, tagBasedResourceIds, metric)) {
-      return false;
-    }
-    return true;
-  }
-
-  /** Check if a metric is matched in `aws_dimension_select` */
-  private boolean metricsIsInAwsDimensionSelect(MetricRule rule, Metric metric) {
-    Set<String> dimensionSelectKeys = rule.awsDimensionSelect.keySet();
-    for (Dimension dimension : metric.dimensions()) {
-      String dimensionName = dimension.name();
-      String dimensionValue = dimension.value();
-      if (dimensionSelectKeys.contains(dimensionName)) {
-        List<String> allowedDimensionValues = rule.awsDimensionSelect.get(dimensionName);
-        if (!allowedDimensionValues.contains(dimensionValue)) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  /** Check if a metric is matched in `aws_dimension_select_regex` */
-  private boolean metricIsInAwsDimensionSelectRegex(MetricRule rule, Metric metric) {
-    Set<String> dimensionSelectRegexKeys = rule.awsDimensionSelectRegex.keySet();
-    for (Dimension dimension : metric.dimensions()) {
-      String dimensionName = dimension.name();
-      String dimensionValue = dimension.value();
-      if (dimensionSelectRegexKeys.contains(dimensionName)) {
-        List<String> allowedDimensionValues = rule.awsDimensionSelectRegex.get(dimensionName);
-        if (!regexListMatch(allowedDimensionValues, dimensionValue)) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  /** Check if any regex string in a list matches a given input value */
-  protected static boolean regexListMatch(List<String> regexList, String input) {
-    for (String regex : regexList) {
-      if (Pattern.matches(regex, input)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /** Check if a metric is matched in `aws_tag_select` */
-  private boolean metricIsInAwsTagSelect(
-      MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
-    if (rule.awsTagSelect.tagSelections == null) {
-      return true;
-    }
-    for (Dimension dimension : metric.dimensions()) {
-      String dimensionName = dimension.name();
-      String dimensionValue = dimension.value();
-      if (rule.awsTagSelect.resourceIdDimension.equals(dimensionName)
-          && !tagBasedResourceIds.contains(dimensionValue)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   private String toSnakeCase(String str) {
@@ -629,8 +460,8 @@ public class CloudWatchCollector extends Collector implements Describable {
           getResourceTagMappings(rule, config.taggingClient);
       List<String> tagBasedResourceIds = extractResourceIds(resourceTagMappings);
 
-      List<List<Dimension>> dimentionsList =
-          getDimensions(rule, tagBasedResourceIds, config.cloudWatchClient);
+      List<List<Dimension>> dimensionList =
+          config.dimensionSource.getDimensions(rule, tagBasedResourceIds).getDimensions();
       DataGetter dataGetter = null;
       if (rule.useGetMetricData) {
         dataGetter =
@@ -640,7 +471,7 @@ public class CloudWatchCollector extends Collector implements Describable {
                 rule,
                 cloudwatchRequests,
                 cloudwatchMetricsRequested,
-                dimentionsList);
+                dimensionList);
       } else {
         dataGetter =
             new GetMetricStatisticsDataGetter(
@@ -651,7 +482,7 @@ public class CloudWatchCollector extends Collector implements Describable {
                 cloudwatchMetricsRequested);
       }
 
-      for (List<Dimension> dimensions : dimentionsList) {
+      for (List<Dimension> dimensions : dimensionList) {
         MetricRuleData values = dataGetter.metricRuleDataFor(dimensions);
         if (values == null) {
           continue;
@@ -738,7 +569,7 @@ public class CloudWatchCollector extends Collector implements Describable {
                 help(rule, unit, "Average"),
                 baseSamples.get(Statistic.AVERAGE)));
       }
-      for (Map.Entry<String, List<MetricFamilySamples.Sample>> entry : extendedSamples.entrySet()) {
+      for (Entry<String, List<MetricFamilySamples.Sample>> entry : extendedSamples.entrySet()) {
         mfs.add(
             new MetricFamilySamples(
                 baseName + "_" + safeName(toSnakeCase(entry.getKey())),
@@ -819,6 +650,18 @@ public class CloudWatchCollector extends Collector implements Describable {
             "Non-zero if this scrape failed.",
             samples));
     return mfs;
+  }
+
+  private String extractResourceIdFromArn(String arn) {
+    // ARN parsing is based on
+    // https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    String[] arnArray = arn.split(":");
+    String resourceId = arnArray[arnArray.length - 1];
+    if (resourceId.contains("/")) {
+      String[] resourceArray = resourceId.split("/", 2);
+      resourceId = resourceArray[resourceArray.length - 1];
+    }
+    return resourceId;
   }
 
   /** Convenience function to run standalone. */

--- a/src/main/java/io/prometheus/cloudwatch/DefaultDimensionSource.java
+++ b/src/main/java/io/prometheus/cloudwatch/DefaultDimensionSource.java
@@ -1,0 +1,189 @@
+package io.prometheus.cloudwatch;
+
+import io.prometheus.client.Counter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.DimensionFilter;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+
+final class DefaultDimensionSource implements DimensionSource {
+
+  private static final Logger LOGGER = Logger.getLogger(DefaultDimensionSource.class.getName());
+  private final Counter cloudwatchRequests;
+  private final CloudWatchClient cloudWatchClient;
+
+  public DefaultDimensionSource(CloudWatchClient cloudWatchClient, Counter cloudwatchRequests) {
+    this.cloudWatchClient = cloudWatchClient;
+    this.cloudwatchRequests = cloudwatchRequests;
+  }
+
+  public DimensionData getDimensions(MetricRule rule, List<String> tagBasedResourceIds) {
+    if (rule.awsDimensions != null
+        && rule.awsDimensionSelect != null
+        && !rule.awsDimensions.isEmpty()
+        && rule.awsDimensions.size() == rule.awsDimensionSelect.size()
+        && rule.awsDimensionSelect.keySet().containsAll(rule.awsDimensions)
+        && rule.awsTagSelect == null) {
+      // The full list of dimensions is known so no need to request it from cloudwatch.
+      return new DimensionData(permuteDimensions(rule.awsDimensions, rule.awsDimensionSelect));
+    } else {
+      return new DimensionData(listDimensions(rule, tagBasedResourceIds, cloudWatchClient));
+    }
+  }
+
+  private List<List<Dimension>> permuteDimensions(
+      List<String> dimensions, Map<String, List<String>> dimensionValues) {
+    ArrayList<List<Dimension>> result = new ArrayList<>();
+
+    if (dimensions.isEmpty()) {
+      result.add(new ArrayList<>());
+    } else {
+      List<String> dimensionsCopy = new ArrayList<>(dimensions);
+      String dimensionName = dimensionsCopy.remove(dimensionsCopy.size() - 1);
+      for (List<Dimension> permutation : permuteDimensions(dimensionsCopy, dimensionValues)) {
+        for (String dimensionValue : dimensionValues.get(dimensionName)) {
+          Dimension.Builder dimensionBuilder = Dimension.builder();
+          dimensionBuilder.value(dimensionValue);
+          dimensionBuilder.name(dimensionName);
+          ArrayList<Dimension> permutationCopy = new ArrayList<>(permutation);
+          permutationCopy.add(dimensionBuilder.build());
+          result.add(permutationCopy);
+        }
+      }
+    }
+    return result;
+  }
+
+  private List<List<Dimension>> listDimensions(
+      MetricRule rule, List<String> tagBasedResourceIds, CloudWatchClient cloudWatchClient) {
+    List<List<Dimension>> dimensions = new ArrayList<>();
+    if (rule.awsDimensions == null) {
+      dimensions.add(new ArrayList<>());
+      return dimensions;
+    }
+
+    ListMetricsRequest.Builder requestBuilder = ListMetricsRequest.builder();
+    requestBuilder.namespace(rule.awsNamespace);
+    requestBuilder.metricName(rule.awsMetricName);
+
+    // 10800 seconds is 3 hours, this setting causes metrics older than 3 hours to not be listed
+    if (rule.rangeSeconds < 10800) {
+      requestBuilder.recentlyActive("PT3H");
+    }
+
+    List<DimensionFilter> dimensionFilters = new ArrayList<>();
+    for (String dimension : rule.awsDimensions) {
+      dimensionFilters.add(DimensionFilter.builder().name(dimension).build());
+    }
+    requestBuilder.dimensions(dimensionFilters);
+
+    String nextToken = null;
+    do {
+      requestBuilder.nextToken(nextToken);
+      ListMetricsResponse response = cloudWatchClient.listMetrics(requestBuilder.build());
+      cloudwatchRequests.labels("listMetrics", rule.awsNamespace).inc();
+      for (Metric metric : response.metrics()) {
+        if (metric.dimensions().size() != dimensionFilters.size()) {
+          // AWS returns all the metrics with dimensions beyond the ones we ask for,
+          // so filter them out.
+          continue;
+        }
+        if (useMetric(rule, tagBasedResourceIds, metric)) {
+          dimensions.add(metric.dimensions());
+        }
+      }
+      nextToken = response.nextToken();
+    } while (nextToken != null);
+    if (dimensions.isEmpty()) {
+      LOGGER.warning(
+          String.format(
+              "(listDimensions) ignoring metric %s:%s due to dimensions mismatch",
+              rule.awsNamespace, rule.awsMetricName));
+    }
+    return dimensions;
+  }
+
+  /**
+   * Check if a metric should be used according to `aws_dimension_select`,
+   * `aws_dimension_select_regex` and dynamic `aws_tag_select`
+   */
+  private boolean useMetric(MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
+    if (rule.awsDimensionSelect != null && !metricsIsInAwsDimensionSelect(rule, metric)) {
+      return false;
+    }
+    if (rule.awsDimensionSelectRegex != null && !metricIsInAwsDimensionSelectRegex(rule, metric)) {
+      return false;
+    }
+    if (rule.awsTagSelect != null && !metricIsInAwsTagSelect(rule, tagBasedResourceIds, metric)) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Check if a metric is matched in `aws_dimension_select` */
+  private boolean metricsIsInAwsDimensionSelect(MetricRule rule, Metric metric) {
+    Set<String> dimensionSelectKeys = rule.awsDimensionSelect.keySet();
+    for (Dimension dimension : metric.dimensions()) {
+      String dimensionName = dimension.name();
+      String dimensionValue = dimension.value();
+      if (dimensionSelectKeys.contains(dimensionName)) {
+        List<String> allowedDimensionValues = rule.awsDimensionSelect.get(dimensionName);
+        if (!allowedDimensionValues.contains(dimensionValue)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /** Check if a metric is matched in `aws_dimension_select_regex` */
+  private boolean metricIsInAwsDimensionSelectRegex(MetricRule rule, Metric metric) {
+    Set<String> dimensionSelectRegexKeys = rule.awsDimensionSelectRegex.keySet();
+    for (Dimension dimension : metric.dimensions()) {
+      String dimensionName = dimension.name();
+      String dimensionValue = dimension.value();
+      if (dimensionSelectRegexKeys.contains(dimensionName)) {
+        List<String> allowedDimensionValues = rule.awsDimensionSelectRegex.get(dimensionName);
+        if (!regexListMatch(allowedDimensionValues, dimensionValue)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /** Check if any regex string in a list matches a given input value */
+  protected static boolean regexListMatch(List<String> regexList, String input) {
+    for (String regex : regexList) {
+      if (Pattern.matches(regex, input)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Check if a metric is matched in `aws_tag_select` */
+  private boolean metricIsInAwsTagSelect(
+      MetricRule rule, List<String> tagBasedResourceIds, Metric metric) {
+    if (rule.awsTagSelect.tagSelections == null) {
+      return true;
+    }
+    for (Dimension dimension : metric.dimensions()) {
+      String dimensionName = dimension.name();
+      String dimensionValue = dimension.value();
+      if (rule.awsTagSelect.resourceIdDimension.equals(dimensionName)
+          && !tagBasedResourceIds.contains(dimensionValue)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/io/prometheus/cloudwatch/DimensionSource.java
+++ b/src/main/java/io/prometheus/cloudwatch/DimensionSource.java
@@ -1,0 +1,21 @@
+package io.prometheus.cloudwatch;
+
+import java.util.List;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+
+interface DimensionSource {
+
+  DimensionData getDimensions(MetricRule rule, List<String> tagBasedResourceIds);
+
+  class DimensionData {
+    private final List<List<Dimension>> dimensions;
+
+    DimensionData(List<List<Dimension>> dimensions) {
+      this.dimensions = dimensions;
+    }
+
+    List<List<Dimension>> getDimensions() {
+      return dimensions;
+    }
+  }
+}

--- a/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
@@ -1,7 +1,6 @@
 package io.prometheus.cloudwatch;
 
 import io.prometheus.client.Counter;
-import io.prometheus.cloudwatch.CloudWatchCollector.MetricRule;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;

--- a/src/main/java/io/prometheus/cloudwatch/GetMetricStatisticsDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricStatisticsDataGetter.java
@@ -1,7 +1,6 @@
 package io.prometheus.cloudwatch;
 
 import io.prometheus.client.Counter;
-import io.prometheus.cloudwatch.CloudWatchCollector.MetricRule;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,7 @@ class GetMetricStatisticsDataGetter implements DataGetter {
     return toMetricValues(latestDp);
   }
 
-  private Datapoint getNewestDatapoint(java.util.List<Datapoint> datapoints) {
+  private Datapoint getNewestDatapoint(List<Datapoint> datapoints) {
     Datapoint newest = null;
     for (Datapoint d : datapoints) {
       if (newest == null || newest.timestamp().isBefore(d.timestamp())) {

--- a/src/main/java/io/prometheus/cloudwatch/MetricRule.java
+++ b/src/main/java/io/prometheus/cloudwatch/MetricRule.java
@@ -1,0 +1,70 @@
+package io.prometheus.cloudwatch;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.awssdk.services.cloudwatch.model.Statistic;
+
+class MetricRule {
+  String awsNamespace;
+  String awsMetricName;
+  int periodSeconds;
+  int rangeSeconds;
+  int delaySeconds;
+  List<Statistic> awsStatistics;
+  List<String> awsExtendedStatistics;
+  List<String> awsDimensions;
+  Map<String, List<String>> awsDimensionSelect;
+  Map<String, List<String>> awsDimensionSelectRegex;
+  CloudWatchCollector.AWSTagSelect awsTagSelect;
+  String help;
+  boolean cloudwatchTimestamp;
+  boolean useGetMetricData;
+  Duration listMetricsCacheTtl;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MetricRule that = (MetricRule) o;
+
+    if (periodSeconds != that.periodSeconds) return false;
+    if (rangeSeconds != that.rangeSeconds) return false;
+    if (delaySeconds != that.delaySeconds) return false;
+    if (cloudwatchTimestamp != that.cloudwatchTimestamp) return false;
+    if (useGetMetricData != that.useGetMetricData) return false;
+    if (!Objects.equals(awsNamespace, that.awsNamespace)) return false;
+    if (!Objects.equals(awsMetricName, that.awsMetricName)) return false;
+    if (!Objects.equals(awsStatistics, that.awsStatistics)) return false;
+    if (!Objects.equals(awsExtendedStatistics, that.awsExtendedStatistics)) return false;
+    if (!Objects.equals(awsDimensions, that.awsDimensions)) return false;
+    if (!Objects.equals(awsDimensionSelect, that.awsDimensionSelect)) return false;
+    if (!Objects.equals(awsDimensionSelectRegex, that.awsDimensionSelectRegex)) return false;
+    if (!Objects.equals(awsTagSelect, that.awsTagSelect)) return false;
+    if (!Objects.equals(help, that.help)) return false;
+    return Objects.equals(listMetricsCacheTtl, that.listMetricsCacheTtl);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = awsNamespace != null ? awsNamespace.hashCode() : 0;
+    result = 31 * result + (awsMetricName != null ? awsMetricName.hashCode() : 0);
+    result = 31 * result + periodSeconds;
+    result = 31 * result + rangeSeconds;
+    result = 31 * result + delaySeconds;
+    result = 31 * result + (awsStatistics != null ? awsStatistics.hashCode() : 0);
+    result = 31 * result + (awsExtendedStatistics != null ? awsExtendedStatistics.hashCode() : 0);
+    result = 31 * result + (awsDimensions != null ? awsDimensions.hashCode() : 0);
+    result = 31 * result + (awsDimensionSelect != null ? awsDimensionSelect.hashCode() : 0);
+    result =
+        31 * result + (awsDimensionSelectRegex != null ? awsDimensionSelectRegex.hashCode() : 0);
+    result = 31 * result + (awsTagSelect != null ? awsTagSelect.hashCode() : 0);
+    result = 31 * result + (help != null ? help.hashCode() : 0);
+    result = 31 * result + (cloudwatchTimestamp ? 1 : 0);
+    result = 31 * result + (useGetMetricData ? 1 : 0);
+    result = 31 * result + (listMetricsCacheTtl != null ? listMetricsCacheTtl.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/test/java/io/prometheus/cloudwatch/CachingDimensionExpiryTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CachingDimensionExpiryTest.java
@@ -1,0 +1,107 @@
+package io.prometheus.cloudwatch;
+
+import static org.junit.Assert.assertEquals;
+
+import io.prometheus.cloudwatch.CachingDimensionSource.DimensionCacheKey;
+import io.prometheus.cloudwatch.CachingDimensionSource.DimensionExpiry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class CachingDimensionExpiryTest {
+
+  private final DimensionSource.DimensionData emptyData =
+      new DimensionSource.DimensionData(Collections.emptyList());
+
+  @Test
+  public void expireAfterCreateUsesDefaultWithEmptyOverrides() {
+    Duration defaultExpiry = Duration.ofSeconds(35);
+    List<MetricRule> expiryOverrides = Collections.emptyList();
+    DimensionExpiry sut = new DimensionExpiry(defaultExpiry, expiryOverrides);
+
+    long afterCreate =
+        sut.expireAfterCreate(
+            createDimensionCacheKey("AWS/Redshift", "WriteIOPS", 0),
+            emptyData,
+            Instant.now().toEpochMilli());
+
+    assertEquals(35, Duration.ofNanos(afterCreate).toSeconds());
+  }
+
+  @Test
+  public void expireAfterCreateUsesMetricLevelOverride() {
+    Duration defaultExpiry = Duration.ofSeconds(35);
+    List<MetricRule> expiryOverrides = List.of(createMetricRule("AWS/S3", "BucketSizeBytes", 100));
+    DimensionExpiry sut = new DimensionExpiry(defaultExpiry, expiryOverrides);
+
+    long afterCreate =
+        sut.expireAfterCreate(
+            createDimensionCacheKey("AWS/S3", "BucketSizeBytes", 100),
+            emptyData,
+            Instant.now().toEpochMilli());
+
+    assertEquals(100, Duration.ofNanos(afterCreate).toSeconds());
+  }
+
+  @Test
+  public void expireAfterCreateUsesDefaultIfNoMatchedOverride() {
+    Duration defaultExpiry = Duration.ofSeconds(35);
+    List<MetricRule> expiryOverrides = List.of(createMetricRule("AWS/S3", "BucketSizeBytes", 100));
+    DimensionExpiry sut = new DimensionExpiry(defaultExpiry, expiryOverrides);
+
+    long afterCreate =
+        sut.expireAfterCreate(
+            createDimensionCacheKey("AWS/Redshift", "WriteIOPS", 120),
+            emptyData,
+            Instant.now().toEpochMilli());
+
+    assertEquals(35, Duration.ofNanos(afterCreate).toSeconds());
+  }
+
+  @Test
+  public void expireAfterUpdateUsesCurrentDuration() {
+    Duration defaultExpiry = Duration.ofSeconds(35);
+    List<MetricRule> expiryOverrides = Collections.emptyList();
+    DimensionExpiry sut = new DimensionExpiry(defaultExpiry, expiryOverrides);
+
+    long afterUpdate =
+        sut.expireAfterUpdate(
+            createDimensionCacheKey("AWS/Redshift", "WriteIOPS", 120),
+            emptyData,
+            Instant.now().toEpochMilli(),
+            10_000_000);
+
+    assertEquals(10_000_000, afterUpdate);
+  }
+
+  @Test
+  public void expireAfterReadUsesCurrentDuration() {
+    Duration defaultExpiry = Duration.ofSeconds(35);
+    List<MetricRule> expiryOverrides = Collections.emptyList();
+    DimensionExpiry sut = new DimensionExpiry(defaultExpiry, expiryOverrides);
+
+    long afterRead =
+        sut.expireAfterRead(
+            createDimensionCacheKey("AWS/Redshift", "WriteIOPS", 100),
+            emptyData,
+            Instant.now().toEpochMilli(),
+            20_000_000);
+    assertEquals(20_000_000, afterRead);
+  }
+
+  private DimensionCacheKey createDimensionCacheKey(
+      String namespace, String name, int ttlInSeconds) {
+    return new DimensionCacheKey(
+        createMetricRule(namespace, name, ttlInSeconds), Collections.emptyList());
+  }
+
+  private MetricRule createMetricRule(String namespace, String name, int ttlInSeconds) {
+    MetricRule metricRule = new MetricRule();
+    metricRule.awsNamespace = namespace;
+    metricRule.awsMetricName = name;
+    metricRule.listMetricsCacheTtl = Duration.ofSeconds(ttlInSeconds);
+    return metricRule;
+  }
+}

--- a/src/test/java/io/prometheus/cloudwatch/CachingDimensionSourceTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CachingDimensionSourceTest.java
@@ -16,7 +16,7 @@ public class CachingDimensionSourceTest {
   public void cachedFromDelegate() {
     DimensionCacheConfig config = new DimensionCacheConfig(Duration.ofSeconds(60));
     FakeDimensionSource source = new FakeDimensionSource();
-    DimensionSource sut = CachingDimensionSource.create(source, config);
+    DimensionSource sut = new CachingDimensionSource(source, config);
 
     sut.getDimensions(createMetricRule("AWS/Redshift", "WriteIOPS"), Collections.emptyList());
     sut.getDimensions(createMetricRule("AWS/Redshift", "WriteIOPS"), Collections.emptyList());

--- a/src/test/java/io/prometheus/cloudwatch/CachingDimensionSourceTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CachingDimensionSourceTest.java
@@ -1,0 +1,48 @@
+package io.prometheus.cloudwatch;
+
+import static io.prometheus.cloudwatch.DimensionSource.DimensionData;
+import static org.junit.Assert.assertEquals;
+
+import io.prometheus.cloudwatch.CachingDimensionSource.DimensionCacheConfig;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+
+public class CachingDimensionSourceTest {
+
+  @Test
+  public void cachedFromDelegate() {
+    DimensionCacheConfig config = new DimensionCacheConfig(Duration.ofSeconds(60));
+    FakeDimensionSource source = new FakeDimensionSource();
+    DimensionSource sut = CachingDimensionSource.create(source, config);
+
+    sut.getDimensions(createMetricRule("AWS/Redshift", "WriteIOPS"), Collections.emptyList());
+    sut.getDimensions(createMetricRule("AWS/Redshift", "WriteIOPS"), Collections.emptyList());
+    DimensionData expected =
+        sut.getDimensions(createMetricRule("AWS/Redshift", "WriteIOPS"), Collections.emptyList());
+
+    Dimension dimension = Dimension.builder().name("AWS/Redshift").value("WriteIOPS").build();
+    assertEquals(1, source.called);
+    assertEquals(dimension, expected.getDimensions().get(0).get(0));
+  }
+
+  private MetricRule createMetricRule(String namespace, String name) {
+    MetricRule metricRule = new MetricRule();
+    metricRule.awsNamespace = namespace;
+    metricRule.awsMetricName = name;
+    return metricRule;
+  }
+
+  static class FakeDimensionSource implements DimensionSource {
+    int called = 0;
+
+    @Override
+    public DimensionData getDimensions(MetricRule rule, List<String> tagBasedResourceIds) {
+      called++;
+      return new DimensionData(
+          List.of(List.of(Dimension.builder().name("AWS/Redshift").value("WriteIOPS").build())));
+    }
+  }
+}

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -1,11 +1,12 @@
 package io.prometheus.cloudwatch;
 
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import io.prometheus.client.Collector;
@@ -20,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -1821,5 +1823,127 @@ public class CloudWatchCollectorTest {
               releaseDate != null ? releaseDate : "unknown"
             }),
         .00001);
+  }
+
+  @Test
+  public void testDimensionsWithDefaultCache() throws Exception {
+    new CloudWatchCollector(
+            "---\nregion: reg\nlist_metrics_cache_ttl: 500\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
+
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+
+    Mockito.verify(cloudWatchClient).listMetrics(any(ListMetricsRequest.class));
+    Mockito.verify(cloudWatchClient, times(2))
+        .getMetricStatistics(any(GetMetricStatisticsRequest.class));
+  }
+
+  @Test
+  public void testDimensionsWithMetricLevelCache() throws Exception {
+    new CloudWatchCollector(
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  list_metrics_cache_ttl: 500\n  aws_dimensions:\n  - AvailabilityZone\n  - LoadBalancerName",
+            cloudWatchClient,
+            taggingClient)
+        .register(registry);
+
+    Mockito.when(
+            cloudWatchClient.listMetrics(
+                (ListMetricsRequest)
+                    argThat(
+                        new ListMetricsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimensions("AvailabilityZone", "LoadBalancerName"))))
+        .thenReturn(
+            ListMetricsResponse.builder()
+                .metrics(
+                    Metric.builder()
+                        .dimensions(
+                            Dimension.builder().name("AvailabilityZone").value("a").build(),
+                            Dimension.builder().name("LoadBalancerName").value("myLB").build())
+                        .build())
+                .build());
+
+    Mockito.when(
+            cloudWatchClient.getMetricStatistics(
+                (GetMetricStatisticsRequest)
+                    argThat(
+                        new GetMetricStatisticsRequestMatcher()
+                            .Namespace("AWS/ELB")
+                                .MetricName("RequestCount")
+                                .Dimension("AvailabilityZone", "a")
+                                .Dimension("LoadBalancerName", "myLB"))))
+        .thenReturn(
+            GetMetricStatisticsResponse.builder()
+                .datapoints(
+                    Datapoint.builder().timestamp(new Date().toInstant()).average(2.0).build())
+                .build());
+
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+    assertEquals(
+        2.0,
+        registry.getSampleValue(
+            "aws_elb_request_count_average",
+            new String[] {"job", "instance", "availability_zone", "load_balancer_name"},
+            new String[] {"aws_elb", "", "a", "myLB"}),
+        .01);
+
+    Mockito.verify(cloudWatchClient).listMetrics(any(ListMetricsRequest.class));
+    Mockito.verify(cloudWatchClient, times(2))
+        .getMetricStatistics(any(GetMetricStatisticsRequest.class));
   }
 }

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
This changes uses the [Caffeine](https://github.com/ben-manes/caffeine) library to provide the mechanism to cache results of the ListMetrics API. This can be configured using the global or metric level setting `list_metrics_cache_ttl` which specifies the TTL in seconds. I have initially opted to include a default value which results in no caching.

For example:

At a global level
```
region: eu-west-1
list_metrics_cache_ttl: 600 # 600 seconds
metrics: 
..
```

At a metric level
```
- aws_dimensions:
    - InstanceId
  aws_metric_name: CPUUtilization
  aws_namespace: AWS/EC2
  aws_statistics:
    - Average
  list_metrics_cache_ttl: 300 # 300 seconds
  aws_tag_select:
     tag_selections:
       Monitoring: ["enabled"]
    resource_type_selection: ec2:instance
    resource_id_dimension: InstanceId
 ```

Questions

- Is introducing an additional dependency for this purpose acceptable? 
- Is it necessary to provide the granularity to cache this request at a metric level? This API may not be called too frequently and therefore it might be more beneficial to implement a more simple version of this logic.

Thanks