### PR TITLE
Update snakeyaml to 1.32 for security updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.30</version>
+      <version>1.32</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>


### PR DESCRIPTION
CVE-2022-38752
CVE-2022-25857

both are YAML parsing issues on untrusted input, so are unlikely to be exposed unless someone is providing CWE-as-a-Service. Nonetheless, we upgrade to keep things neat.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>