### PR TITLE
Fix measurement of cloudwatch_metrics_requested_total

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
@@ -24,7 +24,6 @@ class GetMetricDataDataGetter implements DataGetter {
 
   private static final int MAX_QUERIES_PER_REQUEST = 500;
   // https://aws.amazon.com/cloudwatch/pricing/
-  private static final int MAX_STATS_PER_BILLED_METRIC_REQUEST = 5;
   private final long start;
   private final MetricRule rule;
   private final CloudWatchClient client;
@@ -68,8 +67,7 @@ class GetMetricDataDataGetter implements DataGetter {
         queries.add(query);
       }
     }
-    double metricRequested = Math.ceil((double) stats.size() / MAX_STATS_PER_BILLED_METRIC_REQUEST);
-    metricRequestedForBilling += metricRequested;
+    metricRequestedForBilling += stats.size();
     return queries;
   }
 


### PR DESCRIPTION
As I read the existing code, it's trying to count the number of GetMetricData API calls made, but AWS is billing for every statistic within that. I'm seeing a discrepancy between what cloudwatch_exporter reports and what AWS bills us by a factor of 2-5x, depending on how I slice it.

Per the [AWS documentation](https://aws.amazon.com/cloudwatch/pricing/), "You can request up to five statistics for the same metric in a single GetMetricData API request. Additional statistics are billed as an additional metric."

So even though we can coalesce multiple statistics into a single API call, they're billed by AWS as if they were in individual API calls, so we should be measuring the full count, not dividing by five, to properly account for what AWS is charging.