### PR TITLE
Add issue template for metrics issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,47 +8,50 @@ assignees: ''
 ---
 
 ### What did you do
-Please provide steps for us to reproduce this issue? Example for config file are very welcomed!
+
+<!-- Please provide steps for us to reproduce this issue? Example for config file are very welcomed! -->
 
 ### What did you expect to see?
 
-
 ### What did you see instead? Under which circumstances?
 
-
 ### Are you currently working around this issue?
-How are you currently solving this problem?
+
+<!-- How are you currently solving this problem? -->
 
 ### Additional context
-Anything else we should know?
 
-### Attachments
-If you think you might have additional information that you'd like to include via an attachment, please do - we'll take a look. (Remember to remove any personally-identifiable information.)
+<!-- Anything else we should know? -->
+
+<!-- If you think you might have additional information that you'd like to include via an attachment, please do - we'll take a look. (Remember to remove any personally-identifiable information.) -->
 
 ### Environment
+
 * Exporter version: `X.X.X`
 * Operating system & architecture: `XX` <!-- `uname -a` or equivalent -->
 * Running in containers? y/n
 * Using the official image? y/n
 
-
 <!-- Remember to clear private information -->
 ### Exporter configuration file
+
 <details>
-<summary>expand</summary>
+    <summary>expand</summary>
 
 ```yaml
 
 ```
+
 </details>
 
-
 ### Logs
+
 <!-- Remember to clear private information -->
 <details>
 <summary>expand</summary>
 
-```
+```log
 (paste log lines here)
 ```
+
 </details>

--- a/.github/ISSUE_TEMPLATE/metrics.md
+++ b/.github/ISSUE_TEMPLATE/metrics.md
@@ -1,0 +1,51 @@
+---
+name: 'Metrics issue'
+about: Request help getting metrics out of CloudWatch 📈
+title: "[metrics]: short description here"
+labels: metrics-configuration
+assignees: ''
+
+---
+
+### Context information
+
+<!-- To help us help you, please fill in the following -->
+
+* AWS service:
+* CloudWatch namespace:
+* Link to metrics documentation for this service:
+* AWS region of the exporter:
+* AWS region of the service:
+
+<details>
+    <summary>
+        Exporter configuration
+    </summary>
+
+<!-- insert your exporter configuration in the block below -->
+```yaml
+
+
+
+
+```
+
+</details>
+
+<details>
+    <summary>
+        Exporter logs
+    </summary>
+
+<!-- Run the exporter with `warn_on_empty_list_dimensions: true` and paste the logs below -->
+```log
+
+```
+
+### What do you expect to happen?
+
+<!-- Please describe your desired outcome -->
+
+### What happened instead?
+
+<!-- Please describe the real outcome, in your own words -->

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -6,15 +6,15 @@ labels: enhancement
 assignees: ''
 
 ---
-# Proposal
-###  Use case. Why is this important?
+## Use case. Why is this important?
 
 <!-- Please describe how this enhancement would improve your user experience -->
 
-<!-- If changed configuration required -->
-### How do you think the new configuration should look like?
+## How do you think the new configuration should look like?
 
+<!-- If changed configuration required -->
 Example:
+
 ```yaml
 
 ```


### PR DESCRIPTION
These are commonly reported as "bugs" but are really down to
peculiarities in CloudWatch. Add a separate issue template and collect
more information that will help with this.
