### PR TITLE
Remove explicit dependency on Jackson XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,18 +76,6 @@
       <artifactId>slf4j-jdk14</artifactId>
       <version>1.7.36</version>
     </dependency>
-    <!--
-      Older versions of jackson-databind have remote code execution vulnerabilities
-      CVEs - 2018-5968, 2017-17485, 2017-7525, 2017-15095, 2018-7489, 2018-19360,
-      2018-19361, 2018-19362
-      This cannot be upgraded directly in aws-java-sdk because it requires
-      jackson-databind 2.6 to support Java 6 customers
-    -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.13.3</version>
-    </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
This is no longer necessary as the AWS SDK includes its own shadow copy:

https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-2-17-removes-its-external-dependency-on-jackson/