### PR TITLE
Update AWS SDK to 2.20.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.releaseDate>${maven.build.timestamp}</project.releaseDate>
-    <software.amazon.awssdk.version>2.17.206</software.amazon.awssdk.version>
+    <software.amazon.awssdk.version>2.20.5</software.amazon.awssdk.version>
     <io.prometheus.version>0.16.0</io.prometheus.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
To address security issues in transitive dependencies (Netty) as per #485