### PR TITLE
Update Prometheus common orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,4 +127,4 @@ workflows:
             branches:
               only: master
 orbs:
-  prometheus: prometheus/prometheus@0.16.0
+  prometheus: prometheus/prometheus@0.17.1


### PR DESCRIPTION
to fix issues with binfmt after the CircleCI infrastructure migration