### PR TITLE
Update pom.xml to use newer version of AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.releaseDate>${maven.build.timestamp}</project.releaseDate>
-    <software.amazon.awssdk.version>2.25.15</software.amazon.awssdk.version>
+    <software.amazon.awssdk.version>2.26.25</software.amazon.awssdk.version>
     <io.prometheus.version>0.16.0</io.prometheus.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
## Description

This PR bumps the AWS SDK to pull in a newer version of Netty as v4.1.107.Final has been flagged with a CVE https://nvd.nist.gov/vuln/detail/CVE-2024-29025 for io.netty_netty-codec-http

## Testing

Confirmed newer version of affected package is pulled in 
```
Downloading from central: https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.111.Final/netty-codec-http-4.1.111.Final.pom
Downloaded from central: https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/4.1.111.Final/netty-codec-http-4.1.111.Final.pom (4.4 kB at 546 kB/s)
```