### PR TITLE
fix metricRequestedForBilling to use queries.size() instead of stats.size()

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
@@ -67,7 +67,7 @@ class GetMetricDataDataGetter implements DataGetter {
         queries.add(query);
       }
     }
-    metricRequestedForBilling += stats.size();
+    metricRequestedForBilling += queries.size();
     return queries;
   }
 


### PR DESCRIPTION
This change fixes how the exporter counts the metrics that will be billed for the GetMetricData request.

The YACE already fixed this in their implementation as seen here: https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/pkg/clients/cloudwatch/v2/client.go#L117

![image](https://github.com/user-attachments/assets/084ddeb3-3892-434c-a7ee-f00ba486d8b1)
