### PR TITLE
fix how the metricRequestedForBilling is counted to use queries.size()

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
+++ b/src/main/java/io/prometheus/cloudwatch/GetMetricDataDataGetter.java
@@ -67,7 +67,7 @@ class GetMetricDataDataGetter implements DataGetter {
         queries.add(query);
       }
     }
-    metricRequestedForBilling += stats.size();
+    metricRequestedForBilling += queries.size();
     return queries;
   }
 


### PR DESCRIPTION
This change fixes how the exporter counts the metrics that will be billed for the GetMetricData request.

The YACE already fixed this in their implementation as seen here: https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/pkg/clients/cloudwatch/v2/client.go#L117

![image](https://github.com/user-attachments/assets/6048f3ee-1f8a-4550-917a-fa9ef0c56a58)

**EXAMPLE**

```
MetricDataQueries=[
        {
            'Id': 'foo',
            'MetricStat': {
                'Metric': {
                    'Namespace': 'AWS/DynamoDB',
                    'MetricName': 'ConsumedWriteCapacityUnits',
                    'Dimensions': [
                        {'Name': 'TableName',
                         'Value': 'one-table'}
                    ]
                },
                'Period': 300,   # 5 minutes
                'Stat': 'Sum',
                'Unit': 'Count'
            },
            'ReturnData': True,
        },
        {
            'Id': 'bar',
            'MetricStat': {
                'Metric': {
                    'Namespace': 'AWS/DynamoDB',
                    'MetricName': 'ConsumedWriteCapacityUnits',
                    'Dimensions': [
                        {'Name': 'TableName',
                         'Value': 'another-table'}
                    ]
                },
                'Period': 300,   # 5 minutes
                'Stat': 'Sum',
                'Unit': 'Count'
            },
            'ReturnData': True,
        }
    ]
```
    
For this scenario YACE would increase 2 to the counter metric while this exporter would increase by 1 only