### PR TITLE
Bump AWS aws-sdk-java-v2 to pull in a fix for a NettyIO CVE-2024-47535

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.releaseDate>${maven.build.timestamp}</project.releaseDate>
-    <software.amazon.awssdk.version>2.29.7</software.amazon.awssdk.version>
+    <software.amazon.awssdk.version>2.29.12</software.amazon.awssdk.version>
     <io.prometheus.version>0.16.0</io.prometheus.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
## Description

NettyIO has a CVE https://nvd.nist.gov/vuln/detail/CVE-2024-47535 thats fixed in version `4.1.115`. 

Version 2.29.12 of the AWS SDK https://github.com/aws/aws-sdk-java-v2/commits/2.29.12/ includes this PR https://github.com/aws/aws-sdk-java-v2/commit/b1a52e9e38a91afbade0f4c5ef55b5be3492aff0 which pulls in the fixed version of Netty 