### PR TITLE
Bumped jetty-servlet version for CVE-2024-6763

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>11.0.24</version>
+      <version>12.0.17</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
This CVE affects jetty-servlet https://access.redhat.com/security/cve/cve-2024-6763