### PR TITLE
Update pom.xml to bump jetty servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>11.0.24</version>
+      <version>12.0.16</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
Bumping Jetty servlet to address CVE-2024-6763

https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server/12.0.16