### PR TITLE
Refactor container publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
   pull_request:
   push:
     branches:
-      - "**"
+      - main
+      - master
+      - "release-*"
     tags:
       - "v*"
 
@@ -37,55 +39,10 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
 
-  build_image:
-    name: Build container image
+  publish:
+    name: Build and publish container image
     runs-on: ubuntu-latest
     needs: build
-    if: |
-      github.event_name == 'pull_request'
-      ||
-      (
-        github.event_name == 'push'
-        &&
-        github.ref != 'refs/heads/master'
-        &&
-        !startsWith(github.ref, 'refs/tags/')
-      )
-    env:
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Build image
-        run: |
-          docker buildx build \
-            --progress plain \
-            --platform "$BUILDX_PLATFORMS" \
-            .
-
-  publish_image:
-    name: Publish container image
-    runs-on: ubuntu-latest
-    needs: build
-    if: |
-      github.repository_owner == 'prometheus'
-      &&
-      github.event_name == 'push'
-      &&
-      (
-        github.ref == 'refs/heads/master'
-        ||
-        startsWith(github.ref, 'refs/tags/v')
-      )
-    env:
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -95,28 +52,40 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to quay.io
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_IO_LOGIN }}
           password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build and push image
-        run: |
-          tags=(master)
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            tags+=(latest)
-          fi
-
-          docker buildx build \
-            --progress plain \
-            --platform "$BUILDX_PLATFORMS" \
-            "${tags[@]/#/--tag=quay.io/prometheus/cloudwatch-exporter:}" \
-            "${tags[@]/#/--tag=prom/cloudwatch-exporter:}" \
-            --push .
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: |
+            prom/cloudwatch-exporter
+            quay.io/prometheus/cloudwatch-exporter
+          tags: |
+            # Tag with branch name
+            type=ref,event=branch
+            # Tag with semver from git tag
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+      - name: Build and publish container
+        id: publish
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
       - name: List images
         run: docker images


### PR DESCRIPTION
* Simplify build and publish into a single workflow.
* Use `docker/metadata-action` to generate container tags.
* Skip publish on `pull_request`.