### PR TITLE
fix: Fixed Javadoc warnings

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/BuildInfoCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/BuildInfoCollector.java
@@ -8,8 +8,12 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/** Collects build version and release date information as a gauge metric. */
 public class BuildInfoCollector extends Collector {
   private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
+
+  /** Constructs a BuildInfoCollector. */
+  public BuildInfoCollector() {}
 
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples> mfs = new ArrayList<>();

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -43,6 +43,10 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
+/**
+ * Collects AWS CloudWatch metrics and exports them in Prometheus format. Configured via YAML with
+ * per-metric rules for namespace, metric name, dimensions, statistics, and period.
+ */
 public class CloudWatchCollector extends Collector implements Describable {
   private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
 
@@ -103,15 +107,32 @@ public class CloudWatchCollector extends Collector implements Describable {
           "ProvisionedReadCapacityUnits", "ProvisionedWriteCapacityUnits",
           "ReadThrottleEvents", "WriteThrottleEvents");
 
+  /**
+   * Constructs a CloudWatchCollector from a YAML configuration reader.
+   *
+   * @param in reader for the YAML configuration
+   */
   public CloudWatchCollector(Reader in) {
     loadConfig(in, null, null);
   }
 
+  /**
+   * Constructs a CloudWatchCollector from a YAML configuration string.
+   *
+   * @param yamlConfig YAML configuration as a string
+   */
   public CloudWatchCollector(String yamlConfig) {
     this(yamlConfig, null, null);
   }
 
-  /* For unittests. */
+  /**
+   * Constructs a CloudWatchCollector for unit testing.
+   *
+   * @param jsonConfig YAML/JSON configuration as a string
+   * @param cloudWatchClient pre-configured CloudWatch client, or null to create from config
+   * @param taggingClient pre-configured Resource Groups Tagging API client, or null to create from
+   *     config
+   */
   @SuppressWarnings("unchecked")
   protected CloudWatchCollector(
       String jsonConfig,
@@ -135,6 +156,11 @@ public class CloudWatchCollector extends Collector implements Describable {
     return Collections.emptyList();
   }
 
+  /**
+   * Reloads the configuration from the file specified by {@link WebServer#configFilePath}.
+   *
+   * @throws IOException if the configuration file cannot be read
+   */
   protected void reloadConfig() throws IOException {
     LOGGER.log(Level.INFO, "Reloading configuration");
     try (FileReader reader = new FileReader(WebServer.configFilePath); ) {
@@ -142,6 +168,13 @@ public class CloudWatchCollector extends Collector implements Describable {
     }
   }
 
+  /**
+   * Loads configuration from a reader, reusing existing clients when supplied.
+   *
+   * @param in reader for the YAML configuration
+   * @param cloudWatchClient existing CloudWatch client, or null to create a new one
+   * @param taggingClient existing tagging client, or null to create a new one
+   */
   @SuppressWarnings("unchecked")
   protected void loadConfig(
       Reader in, CloudWatchClient cloudWatchClient, ResourceGroupsTaggingApiClient taggingClient) {
@@ -711,7 +744,11 @@ public class CloudWatchCollector extends Collector implements Describable {
     return "";
   }
 
-  /** Convenience function to run standalone. */
+  /**
+   * Convenience function to run standalone.
+   *
+   * @param args command line arguments; args[0] is the AWS region (defaults to eu-west-1)
+   */
   public static void main(String[] args) {
     String region = "eu-west-1";
     if (args.length > 0) {

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -6,10 +6,18 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/** Servlet endpoint that triggers configuration reload on POST requests. */
 public class DynamicReloadServlet extends HttpServlet {
   private static final long serialVersionUID = 9078784531819993933L;
+
+  /** The CloudWatchCollector whose configuration will be reloaded. */
   private final CloudWatchCollector collector;
 
+  /**
+   * Constructs a DynamicReloadServlet.
+   *
+   * @param collector the CloudWatchCollector to trigger reloads on
+   */
   public DynamicReloadServlet(CloudWatchCollector collector) {
     this.collector = collector;
   }

--- a/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HealthServlet.java
@@ -6,8 +6,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/** Servlet that responds with "ok" for health and readiness checks. */
 public class HealthServlet extends HttpServlet {
   private static final long serialVersionUID = 5543118274931292897L;
+
+  /** Constructs a HealthServlet. */
+  public HealthServlet() {}
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)

--- a/src/main/java/io/prometheus/cloudwatch/HomePageServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/HomePageServlet.java
@@ -6,8 +6,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/** Servlet that serves a simple HTML home page with a link to /metrics. */
 public class HomePageServlet extends HttpServlet {
   private static final long serialVersionUID = 3239704246954810347L;
+
+  /** Constructs a HomePageServlet. */
+  public HomePageServlet() {}
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -12,10 +12,21 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 
+/** Embedded Jetty web server that exposes CloudWatch metrics via HTTP. */
 public class WebServer {
 
+  /** Path to the YAML configuration file set from command-line arguments. */
   public static String configFilePath;
 
+  /** Constructs a WebServer. */
+  public WebServer() {}
+
+  /**
+   * Starts the web server.
+   *
+   * @param args command line arguments; args[0] is the port, args[1] is the YAML config file path
+   * @throws Exception if the server fails to start
+   */
   public static void main(String[] args) throws Exception {
     if (args.length < 2) {
       System.err.println("Usage: WebServer <port> <yml configuration file>");


### PR DESCRIPTION
- Fixed Javadoc warnings
- 2 warnings remain for `sun.misc` classes, which can't be resolved due to the Java 17 target version.