### PR TITLE
fix: Fixed pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>9</version>
+    <relativePath/>
   </parent>
 
   <distributionManagement>


### PR DESCRIPTION
- Fixed Maven build warnings.
- The repository needs some maintenance to be converted to the new Maven Central Publisher Portal process.